### PR TITLE
change default value of some params

### DIFF
--- a/docs/sphinx/en/file_specification/parameter_section.rst
+++ b/docs/sphinx/en/file_specification/parameter_section.rst
@@ -78,8 +78,8 @@ Parameters in the full update procedure.
    ``num_step``,            "Number of full updates",                                                                                      Integer, 0
    ``env_cutoff``,          "Cutoff of singular values to be considered as zero when computing environment through full updates",          Real,    1e-12
    ``inverse_precision``,   "Cutoff of singular values to be considered as zero when computing the pseudoinverse matrix with full update", Real,    1e-12
-   ``convergence_epsilon``, "Convergence criteria for truncation optimization with full update",                                           Real,    1e-12
-   ``iteration_max``,       "Maximum iteration number for truncation optimization on full updates",                                        Integer, 1000
+   ``convergence_epsilon``, "Convergence criteria for truncation optimization with full update",                                           Real,    1e-6
+   ``iteration_max``,       "Maximum iteration number for truncation optimization on full updates",                                        Integer, 100
    ``gauge_fix``,           "Whether the tensor gauge is fixed",                                                                           Boolean, true
    ``fastfullupdate``,      "Whether the Fast full update is adopted",                                                                     Boolean, true
 
@@ -94,7 +94,7 @@ Parameters for corner transfer matrices, CTM.
 
    ``dimension``,                "Bond Dimension of CTM :math:`\chi`",                                                             Integer, 4
    ``projector_cutoff``,         "Cutoff of singular values to be considered as zero when computing CTM projectors",                          Real,    1e-12
-   ``convergence_epsilon``,      "CTM convergence criteria",                                                                                  Real,    1e-10
+   ``convergence_epsilon``,      "CTM convergence criteria",                                                                                  Real,    1e-6
    ``iteration_max``,            "Maximum iteration number of convergence for CTM",                                                           Integer, 100
    ``projector_corner``,         "Whether to use only the 1/4 corner tensor in the CTM projector calculation",                                Boolean, true
    ``use_rsvd``,                 "Whether to replace SVD with Random SVD",                                                                    Boolean, false

--- a/docs/sphinx/ja/file_specification/parameter_section.rst
+++ b/docs/sphinx/ja/file_specification/parameter_section.rst
@@ -82,8 +82,8 @@ full update に関するパラメータ
    ``num_step``,            "full update の回数",                                                 整数,   0
    ``env_cutoff``,          "full update で環境テンソルを計算する際にゼロとみなす特異値のcutoff", 実数,   1e-12
    ``inverse_precision``,   "full update で擬似逆行列を計算する際にゼロとみなす特異値のcutoff",   実数,   1e-12
-   ``convergence_epsilon``, "full update でtruncationの最適化を行う際の収束判定値",               実数,   1e-12
-   ``iteration_max``,       "full update でtruncationの最適化を行う際のiterationの最大回数",      整数,   1000
+   ``convergence_epsilon``, "full update でtruncationの最適化を行う際の収束判定値",               実数,   1e-6
+   ``iteration_max``,       "full update でtruncationの最適化を行う際のiterationの最大回数",      整数,   100
    ``gauge_fix``,           "テンソルのゲージを固定するかどうか",                                 真偽値, true
    ``fastfullupdate``,      "Fast full update にするかどうか",                                    真偽値, true
 
@@ -98,7 +98,7 @@ full update に関するパラメータ
 
    ``dimension``,                "CTM のボンド次元 :math:`\chi`",                                  整数,   4
    ``projector_cutoff``,         "CTMのprojectorを計算する際にゼロとみなす特異値のcutoff",         実数,   1e-12
-   ``convergence_epsilon``,      "CTMの収束判定値",                                                実数,   1e-10
+   ``convergence_epsilon``,      "CTMの収束判定値",                                                実数,   1e-6
    ``iteration_max``,            "CTMの収束iterationの最大回数",                                   整数,   100
    ``projector_corner``,         "CTMのprojector計算で1/4角のテンソルのみを使う",                  真偽値, true
    ``use_rsvd``,                 "SVD を 乱択SVD で置き換えるかどうか",                            真偽値, false

--- a/src/PEPS_Parameters.cpp
+++ b/src/PEPS_Parameters.cpp
@@ -38,9 +38,9 @@ PEPS_Parameters::PEPS_Parameters() {
 
   // Environment
   Inverse_projector_cut = 1e-12;
-  CTM_Convergence_Epsilon = 1e-10;
+  CTM_Convergence_Epsilon = 1e-6;
   Max_CTM_Iteration = 100;
-  CTM_Projector_corner = false;
+  CTM_Projector_corner = true;
   Use_RSVD = false;
   RSVD_Oversampling_factor = 2.0;
 
@@ -48,8 +48,8 @@ PEPS_Parameters::PEPS_Parameters() {
   num_full_step = 0;
   Inverse_Env_cut = 1e-12;
   Full_Inverse_precision = 1e-12;
-  Full_Convergence_Epsilon = 1e-12;
-  Full_max_iteration = 1000;
+  Full_Convergence_Epsilon = 1e-6;
+  Full_max_iteration = 100;
   Full_Gauge_Fix = true;
   Full_Use_FastFullUpdate = true;
 

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -43,6 +43,36 @@ TEST_CASE("input") {
   using ptensor = mptensor::Tensor<mptensor::scalapack::Matrix, std::complex<double>>;
 #endif
 
+
+  SUBCASE("parameter_default") {
+    INFO("parameter_default");
+    auto toml = parse_str(R"([parameter])");
+
+    PEPS_Parameters peps_parameters = gen_param(toml->get_table("parameter"));
+
+    CHECK(peps_parameters.CHI == 2);
+
+    CHECK(peps_parameters.num_simple_step == 0);
+    CHECK(peps_parameters.Inverse_lambda_cut == 1e-12);
+
+    CHECK(peps_parameters.num_full_step == 0);
+    CHECK(peps_parameters.Inverse_Env_cut == 1e-12);
+    CHECK(peps_parameters.Full_Inverse_precision == 1e-12);
+    CHECK(peps_parameters.Full_Convergence_Epsilon == 1e-6);
+    CHECK(peps_parameters.Full_max_iteration == 100);
+    CHECK(peps_parameters.Full_Gauge_Fix == true);
+    CHECK(peps_parameters.Full_Use_FastFullUpdate == true);
+
+    CHECK(peps_parameters.Inverse_projector_cut == 1e-12);
+    CHECK(peps_parameters.CTM_Convergence_Epsilon == 1e-6);
+    CHECK(peps_parameters.Max_CTM_Iteration == 100);
+    CHECK(peps_parameters.CTM_Projector_corner == true);
+    CHECK(peps_parameters.Use_RSVD == false);
+    CHECK(peps_parameters.RSVD_Oversampling_factor == 2.0);
+
+    CHECK(peps_parameters.seed == 11);
+  }
+
   SUBCASE("parameter") {
     INFO("parameter");
     auto toml = parse_str(R"(
@@ -69,7 +99,7 @@ dimension = 16
 projector_cutoff = 1e-10
 convergence_epsilon = 1e-8
 iteration_max = 10
-projector_corner = true
+projector_corner = false
 use_rsvd = true
 rsvd_oversampling_factor = 3.0
 
@@ -94,7 +124,7 @@ seed = 42)");
     CHECK(peps_parameters.Inverse_projector_cut == 1e-10);
     CHECK(peps_parameters.CTM_Convergence_Epsilon == 1e-8);
     CHECK(peps_parameters.Max_CTM_Iteration == 10);
-    CHECK(peps_parameters.CTM_Projector_corner == true);
+    CHECK(peps_parameters.CTM_Projector_corner == false);
     CHECK(peps_parameters.Use_RSVD == true);
     CHECK(peps_parameters.RSVD_Oversampling_factor == 3.0);
 


### PR DESCRIPTION
- `parameter.full_update`
	- `convergence_epsilon`
		- `1e-12 -> 1e-6`
    - `iteration_max`
		- `1000 -> 100`
- `parameter.ctm`
	- `convergence_epsilon`
		- `1e-10 -> 1e-6`
	- `projector_corner`
		- `false -> true`
		- bugfix: the document said that default was true, but it was false indeed.