### PR TITLE
Write undefined observables (skipped group) no longer in density.dat

### DIFF
--- a/src/iTPS/iTPS.cpp
+++ b/src/iTPS/iTPS.cpp
@@ -168,7 +168,9 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
   }
   num_onesite_operators = maxops + 1;
   onesite_operator_names.resize(num_onesite_operators);
+  onesite_operator_counts.resize(num_onesite_operators);
   for (auto const &op : onesite_operators) {
+    ++onesite_operator_counts[op.group];
     if (op.name.empty()) {
       std::stringstream ss;
       ss << "onesite[" << op.group << "]";
@@ -187,7 +189,9 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
   }
   num_twosite_operators = maxops + 1;
   twosite_operator_names.resize(num_twosite_operators);
+  twosite_operator_counts.resize(num_onesite_operators);
   for (auto const &op : twosite_operators) {
+    ++twosite_operator_counts[op.group];
     if (op.name.empty()) {
       std::stringstream ss;
       ss << "twosite[" << op.group << "]";

--- a/src/iTPS/iTPS.hpp
+++ b/src/iTPS/iTPS.hpp
@@ -179,6 +179,8 @@ class iTPS {
   int num_twosite_operators;
   std::vector<std::string> onesite_operator_names;
   std::vector<std::string> twosite_operator_names;
+  std::vector<int> onesite_operator_counts;
+  std::vector<int> twosite_operator_counts;
 
   std::vector<tensor> op_identity;
 

--- a/src/iTPS/measure.cpp
+++ b/src/iTPS/measure.cpp
@@ -97,6 +97,9 @@ void iTPS<ptensor>::measure() {
 
       if (mpirank == 0) {
         for (int ilops = 0; ilops < num_onesite_operators; ++ilops) {
+          if (onesite_operator_counts[ilops] == 0){
+            continue;
+          }
           const auto v = loc_obs[ilops] * invV;
           ofs << onesite_operator_names[ilops] << " = ";
           if (std::real(v) >= 0.0) {
@@ -110,6 +113,9 @@ void iTPS<ptensor>::measure() {
         }
 
         for (int ilops = 0; ilops < num_twosite_operators; ++ilops) {
+          if (twosite_operator_counts[ilops] == 0){
+            continue;
+          }
           const auto v = two_obs[ilops] * invV;
           ofs << twosite_operator_names[ilops] << " = ";
           if (std::real(v) >= 0.0) {
@@ -137,6 +143,9 @@ void iTPS<ptensor>::measure() {
 
       std::cout << "Onesite observables per site:" << std::endl;
       for (int ilops = 0; ilops < num_onesite_operators; ++ilops) {
+        if ( onesite_operator_counts[ilops] == 0) {
+          continue;
+        }
         const auto v = loc_obs[ilops] * invV;
         std::cout << "  " << onesite_operator_names[ilops] << " = "
                   << std::real(v) << " " << std::imag(v) << std::endl;
@@ -144,6 +153,9 @@ void iTPS<ptensor>::measure() {
 
       std::cout << "Twosite observables per site:" << std::endl;
       for (int ilops = 0; ilops < num_twosite_operators; ++ilops) {
+        if ( twosite_operator_counts[ilops] == 0) {
+          continue;
+        }
         const auto v = two_obs[ilops] * invV;
         std::cout << "  " << twosite_operator_names[ilops] << " = "
                   << std::real(v) << " " << std::imag(v) << std::endl;


### PR DESCRIPTION
An example follows:
When observables with groups 0 and 2 are defined but one with group 1 is not, the undefined observable with group 1 will no longer be saved in `density.dat`.