### PR TITLE
Bbq bugfix

### DIFF
--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -787,7 +787,7 @@ class SpinModel(Model):
 
             ham[in1, in2, out1, out2] = val
             it.iternext()
-        ham += B * SS**2
+        ham += B * np.tensordot(SS,SS,([2,3],[0,1]))
         return ham
 
     def read_params(self, modelparam: Dict[str, Any]) -> None:


### PR DESCRIPTION
I found a bug in tenes_simple when we consider the biquadratic interaction. The tenes_simple incorrectly creates the biquadratic interaction through `SS**2`, where SS is a ndarray representing the bilinear Heisenberg coupling. In Python, SS**2 means element-wise multiplication, while the correct biquadratic term should be created by matrix-matrix multiplication. 
Please review this update. 