### PR TITLE
update format of parameters on ITE

### DIFF
--- a/src/iTPS/PEPS_Parameters.hpp
+++ b/src/iTPS/PEPS_Parameters.hpp
@@ -18,6 +18,7 @@
 #define TENES_SRC_PEPS_PARAMETERS_HPP_
 
 #include <string>
+#include <vector>
 
 #include "../mpi.hpp"
 #include "../printlevel.hpp"
@@ -25,8 +26,7 @@
 namespace tenes {
 namespace itps {
 
-class PEPS_Parameters {
- public:
+struct PEPS_Parameters {
   // Tensor
   int D;    // Bond dimension for central tensor
   int CHI;  // Bond dimension for environment tensor
@@ -34,7 +34,8 @@ class PEPS_Parameters {
   PrintLevel print_level;
 
   // Simple update
-  int num_simple_step;
+  std::vector<int> num_simple_step;
+  std::vector<double> tau_simple_step;
   double Inverse_lambda_cut;
   bool Simple_Gauge_Fix;
   int Simple_Gauge_maxiter;
@@ -50,7 +51,8 @@ class PEPS_Parameters {
   bool MeanField_Env;
 
   // Full update
-  int num_full_step;
+  std::vector<int> num_full_step;
+  std::vector<double> tau_full_step;
   double Inverse_Env_cut;
   double Full_Inverse_precision;
   double Full_Convergence_Epsilon;

--- a/src/iTPS/full_update.cpp
+++ b/src/iTPS/full_update.cpp
@@ -28,17 +28,21 @@ namespace itps {
 
 template <class ptensor>
 void iTPS<ptensor>::full_update() {
-  if (peps_parameters.num_full_step > 0) {
+  const int group = 0;
+  if (peps_parameters.num_full_step[group] > 0) {
     update_CTM();
   }
 
   Timer<> timer;
   ptensor Tn1_new(comm), Tn2_new(comm);
-  const int nsteps = peps_parameters.num_full_step;
+  const int nsteps = peps_parameters.num_full_step[group];
   double next_report = 10.0;
 
   for (int int_tau = 0; int_tau < nsteps; ++int_tau) {
     for (auto up : full_updates) {
+      if (up.group != group) {
+        continue;
+      }
       if (up.is_onesite()) {
         const int source = up.source_site;
         Tn[source] = tensordot(Tn[source], up.op, mptensor::Axes(4), mptensor::Axes(0));

--- a/src/iTPS/iTPS.cpp
+++ b/src/iTPS/iTPS.cpp
@@ -47,8 +47,9 @@ namespace itps {
 
 template <class tensor>
 iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
-                   SquareLattice lattice_, NNOperators<tensor> simple_updates_,
-                   NNOperators<tensor> full_updates_,
+                   SquareLattice lattice_,
+                   EvolutionOperators<tensor> simple_updates_,
+                   EvolutionOperators<tensor> full_updates_,
                    Operators<tensor> onesite_operators_,
                    Operators<tensor> twosite_operators_,
                    CorrelationParameter corparam_,

--- a/src/iTPS/iTPS.cpp
+++ b/src/iTPS/iTPS.cpp
@@ -27,6 +27,7 @@ int omp_get_max_threads() { return 1; }
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <set>
 
 #include <mptensor/rsvd.hpp>
 
@@ -161,6 +162,69 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
   }
 
   initialize_tensors();
+
+  std::set<int> simple_update_groups;
+  bool notwarned = true;
+  for (auto const &op : simple_updates) {
+    auto g = op.group;
+    if (g < 0) {
+      std::stringstream ss;
+      ss << "ERROR: a simple update has negative group number " << g;
+      throw std::runtime_error(ss.str());
+    }
+    if (notwarned && g > 0) {
+      std::cerr << "WARNING: a simple update has nonzero group number " << g
+                << std::endl;
+      std::cerr << "         This feature is reserved for future use."
+                << std::endl;
+      std::cerr << "         Currently, all simple updates with nonzero group "
+                   "number are ignored."
+                << std::endl;
+      notwarned = false;
+    }
+    simple_update_groups.insert(g);
+  }
+  num_simple_update_groups = *simple_update_groups.rbegin() + 1;
+  for (int g = 0; g < num_simple_update_groups; ++g) {
+    auto it = simple_update_groups.find(g);
+    if (it == simple_update_groups.end()) {
+      std::stringstream ss;
+      ss << "ERROR: no simple update with group number " << g;
+      throw std::runtime_error(ss.str());
+    }
+  }
+
+  notwarned = true;
+
+  std::set<int> full_update_groups;
+  for (auto const &op : full_updates) {
+    auto g = op.group;
+    if (g < 0) {
+      std::stringstream ss;
+      ss << "ERROR: a full update has negative group number " << g;
+      throw std::runtime_error(ss.str());
+    }
+    if (notwarned && g > 0) {
+      std::cerr << "WARNING: a full update has nonzero group number " << g
+                << std::endl;
+      std::cerr << "         This feature is reserved for future use."
+                << std::endl;
+      std::cerr << "         Currently, all full updates with nonzero group "
+                   "number are ignored."
+                << std::endl;
+      notwarned = false;
+    }
+    full_update_groups.insert(g);
+  }
+  num_full_update_groups = *full_update_groups.rbegin() + 1;
+  for (int g = 0; g < num_full_update_groups; ++g) {
+    auto it = full_update_groups.find(g);
+    if (it == full_update_groups.end()) {
+      std::stringstream ss;
+      ss << "ERROR: no full update with group number " << g;
+      throw std::runtime_error(ss.str());
+    }
+  }
 
   int maxops = -1;
   size_t maxlength = 0;

--- a/src/iTPS/iTPS.hpp
+++ b/src/iTPS/iTPS.hpp
@@ -172,7 +172,9 @@ class iTPS {
   SquareLattice lattice;
 
   EvolutionOperators<tensor> simple_updates;
+  int num_simple_update_groups;
   EvolutionOperators<tensor> full_updates;
+  int num_full_update_groups;
   Operators<tensor> onesite_operators;
   Operators<tensor> twosite_operators;
   std::vector<std::vector<int>> site_ops_indices;

--- a/src/iTPS/iTPS.hpp
+++ b/src/iTPS/iTPS.hpp
@@ -66,8 +66,8 @@ class iTPS {
    *  @param[in] comm_
    *  @param[in] peps_parameters
    *  @param[in] lattice_
-   *  @param[in] simple_updates ITE operators for simple updates
-   *  @param[in] full_updates ITE operators for full updates
+   *  @param[in] simple_updates Time Evolution operators for simple updates
+   *  @param[in] full_updates Time Evolution operators for full updates
    *  @param[in] onesite_operators_ onesite operators to be measured
    *  @param[in] twosite_operators_ twosite operators to be measured
    *  @param[in] corparam_  parameters for measuring correlation functions
@@ -75,7 +75,8 @@ class iTPS {
    * transfer matrix
    */
   iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_, SquareLattice lattice_,
-       NNOperators<tensor> simple_updates_, NNOperators<tensor> full_updates_,
+       EvolutionOperators<tensor> simple_updates_,
+       EvolutionOperators<tensor> full_updates_,
        Operators<tensor> onesite_operators_,
        Operators<tensor> twosite_operators_, CorrelationParameter corparam_,
        TransferMatrix_Parameters tmatrix_param_);
@@ -170,8 +171,8 @@ class iTPS {
   PEPS_Parameters peps_parameters;
   SquareLattice lattice;
 
-  NNOperators<tensor> simple_updates;
-  NNOperators<tensor> full_updates;
+  EvolutionOperators<tensor> simple_updates;
+  EvolutionOperators<tensor> full_updates;
   Operators<tensor> onesite_operators;
   Operators<tensor> twosite_operators;
   std::vector<std::vector<int>> site_ops_indices;

--- a/src/iTPS/load_toml.hpp
+++ b/src/iTPS/load_toml.hpp
@@ -55,34 +55,30 @@ std::vector<std::tuple<int, int, int>> read_bonds(std::string str);
 
 template <class tensor>
 Operators<tensor> load_operator(decltype(cpptoml::parse_file("")) param,
-                                MPI_Comm comm,
-                                int nsites, int nbody, double atol = 0.0,
+                                MPI_Comm comm, int nsites, int nbody,
+                                double atol = 0.0,
                                 const char *tablename = "observable.onesite");
 
 template <class tensor>
 Operators<tensor> load_operators(decltype(cpptoml::parse_file("")) param,
-                                 MPI_Comm comm,
-                                 int nsites, int nbody, double atol,
-                                 std::string const &key);
-
-template <class tensor>
-NNOperator<tensor> load_nn_operator(decltype(cpptoml::parse_file("")) param,
-                                    MPI_Comm comm,
-                                    double atol = 0.0,
-                                    const char *tablename = "evolution.simple");
-
-template <class tensor>
-NNOperators<tensor> load_updates(decltype(cpptoml::parse_file("")) param,
-                                 MPI_Comm comm,
+                                 MPI_Comm comm, int nsites, int nbody,
                                  double atol, std::string const &key);
+
 template <class tensor>
-NNOperators<tensor> load_simple_updates(decltype(cpptoml::parse_file("")) param,
-                                        MPI_Comm comm,
-                                        double atol = 0.0);
+EvolutionOperator<tensor> load_Evolution_operator(
+    decltype(cpptoml::parse_file("")) param, MPI_Comm comm, double atol = 0.0,
+    const char *tablename = "evolution.simple");
+
 template <class tensor>
-NNOperators<tensor> load_full_updates(decltype(cpptoml::parse_file("")) param,
-                                      MPI_Comm comm,
-                                      double atol = 0.0);
+EvolutionOperators<tensor> load_updates(decltype(cpptoml::parse_file("")) param,
+                                        MPI_Comm comm, double atol,
+                                        std::string const &key);
+template <class tensor>
+EvolutionOperators<tensor> load_simple_updates(
+    decltype(cpptoml::parse_file("")) param, MPI_Comm comm, double atol = 0.0);
+template <class tensor>
+EvolutionOperators<tensor> load_full_updates(
+    decltype(cpptoml::parse_file("")) param, MPI_Comm comm, double atol = 0.0);
 
 }  // namespace itps
 }  // namespace tenes

--- a/src/iTPS/main.cpp
+++ b/src/iTPS/main.cpp
@@ -107,7 +107,7 @@ to_real(tenes::EvolutionOperators<mptensor::Tensor<
     for (size_t lindex = 0; lindex < op.op.local_size(); ++lindex) {
       A[lindex] = op.op[lindex].real();
     }
-    ret.emplace_back(op.source_site, op.source_leg, A);
+    ret.emplace_back(op.source_site, op.source_leg, op.group, A);
   }
   return ret;
 }

--- a/src/iTPS/main.cpp
+++ b/src/iTPS/main.cpp
@@ -91,10 +91,12 @@ bool is_real(tenes::Operators<mptensor::Tensor<
   return true;
 }
 
-tenes::NNOperators<mptensor::Tensor<tenes::mptensor_matrix_type, double>>
-to_real(tenes::NNOperators<mptensor::Tensor<tenes::mptensor_matrix_type,
-                                            std::complex<double>>> const& ops) {
-  tenes::NNOperators<mptensor::Tensor<tenes::mptensor_matrix_type, double>> ret;
+tenes::EvolutionOperators<mptensor::Tensor<tenes::mptensor_matrix_type, double>>
+to_real(tenes::EvolutionOperators<mptensor::Tensor<
+            tenes::mptensor_matrix_type, std::complex<double>>> const& ops) {
+  tenes::EvolutionOperators<
+      mptensor::Tensor<tenes::mptensor_matrix_type, double>>
+      ret;
   if (ops.empty()) {
     return ret;
   }
@@ -110,7 +112,7 @@ to_real(tenes::NNOperators<mptensor::Tensor<tenes::mptensor_matrix_type,
   return ret;
 }
 
-bool is_real(tenes::NNOperators<mptensor::Tensor<
+bool is_real(tenes::EvolutionOperators<mptensor::Tensor<
                  tenes::mptensor_matrix_type, std::complex<double>>> const& ops,
              double tol) {
   for (auto const& op : ops) {
@@ -136,7 +138,8 @@ namespace itps {
 
 template <class tensor>
 int run(MPI_Comm comm, PEPS_Parameters peps_parameters, SquareLattice lattice,
-        NNOperators<tensor> simple_updates, NNOperators<tensor> full_updates,
+        EvolutionOperators<tensor> simple_updates,
+        EvolutionOperators<tensor> full_updates,
         Operators<tensor> onesite_operators,
         Operators<tensor> twosite_operators, CorrelationParameter corparam,
         TransferMatrix_Parameters clength_param) {

--- a/src/iTPS/optimize.cpp
+++ b/src/iTPS/optimize.cpp
@@ -28,7 +28,7 @@ void iTPS<ptensor>::optimize() {
   }
   simple_update();
 
-  if (peps_parameters.num_full_step > 0) {
+  if (peps_parameters.num_full_step[0] > 0) {
     if (peps_parameters.print_level >= PrintLevel::info) {
       std::cout << "Start full update" << std::endl;
     }

--- a/src/iTPS/simple_update.cpp
+++ b/src/iTPS/simple_update.cpp
@@ -24,15 +24,19 @@ namespace itps {
 
 template <class tensor>
 void iTPS<tensor>::simple_update() {
+  const int group = 0;
   Timer<> timer;
   tensor Tn1_new(comm);
   tensor Tn2_new(comm);
   std::vector<double> lambda_c;
-  const int nsteps = peps_parameters.num_simple_step;
+  const int nsteps = peps_parameters.num_simple_step[group];
   double next_report = 10.0;
 
   for (int int_tau = 0; int_tau < nsteps; ++int_tau) {
     for (auto up : simple_updates) {
+      if (up.group != group){
+        continue;
+      }
       if (up.is_onesite()) {
         const int source = up.source_site;
         Tn[source] = tensordot(Tn[source], up.op, mptensor::Axes(4), mptensor::Axes(0));
@@ -118,7 +122,7 @@ void iTPS<tensor>::simple_update() {
                   << nsteps << "] done" << std::endl;
       }
     }
-  }
+  } // end of for (int_tau)
   time_simple_update += timer.elapsed();
 }
 

--- a/src/operator.hpp
+++ b/src/operator.hpp
@@ -82,10 +82,15 @@ template <class tensor>
 struct EvolutionOperator {
   int source_site;
   int source_leg;
+  int group;
   tensor op;
 
-  EvolutionOperator(int source_site, int source_leg, tensor const &op)
-      : source_site(source_site), source_leg(source_leg), op(op) {}
+  EvolutionOperator(int source_site, int source_leg, int group,
+                    tensor const &op)
+      : source_site(source_site),
+        source_leg(source_leg),
+        group(group),
+        op(op) {}
 
   bool is_onesite() const { return source_leg < 0; }
   bool is_twosite() const { return !is_onesite(); }
@@ -94,15 +99,20 @@ struct EvolutionOperator {
 };
 template <class tensor>
 EvolutionOperator<tensor> make_onesite_EvolutionOperator(int source_site,
+                                                         int group,
                                                          tensor const &op) {
   if (source_site < 0) {
     throw std::runtime_error("source_site must be non-negative");
   }
-  return EvolutionOperator<tensor>(source_site, -1, op);
+  if (group < 0) {
+    throw std::runtime_error("group must be non-negative");
+  }
+  return EvolutionOperator<tensor>(source_site, -1, group, op);
 }
 template <class tensor>
 EvolutionOperator<tensor> make_twosite_EvolutionOperator(int source_site,
                                                          int source_leg,
+                                                         int group,
                                                          tensor const &op) {
   if (source_site < 0) {
     throw std::runtime_error("source_site must be non-negative");
@@ -110,7 +120,10 @@ EvolutionOperator<tensor> make_twosite_EvolutionOperator(int source_site,
   if (source_leg < 0 || source_leg > 3) {
     throw std::runtime_error("source_leg must be 0, 1, 2, or 3");
   }
-  return EvolutionOperator<tensor>(source_site, source_leg, op);
+  if (group < 0) {
+    throw std::runtime_error("group must be non-negative");
+  }
+  return EvolutionOperator<tensor>(source_site, source_leg, group, op);
 }
 
 template <class tensor>

--- a/src/operator.hpp
+++ b/src/operator.hpp
@@ -79,24 +79,42 @@ template <class tensor>
 using Operators = std::vector<Operator<tensor>>;
 
 template <class tensor>
-struct NNOperator {
+struct EvolutionOperator {
   int source_site;
   int source_leg;
   tensor op;
 
-  NNOperator(int site, tensor const &op)
-      : source_site(site), source_leg(-1), op(op) {}
-  NNOperator(int site, int leg, tensor const &op)
-      : source_site(site), source_leg(leg), op(op) {}
+  EvolutionOperator(int source_site, int source_leg, tensor const &op)
+      : source_site(source_site), source_leg(source_leg), op(op) {}
 
   bool is_onesite() const { return source_leg < 0; }
   bool is_twosite() const { return !is_onesite(); }
   bool is_horizontal() const { return source_leg % 2 == 0; }
   bool is_vertical() const { return !is_horizontal(); }
 };
+template <class tensor>
+EvolutionOperator<tensor> make_onesite_EvolutionOperator(int source_site,
+                                                         tensor const &op) {
+  if (source_site < 0) {
+    throw std::runtime_error("source_site must be non-negative");
+  }
+  return EvolutionOperator<tensor>(source_site, -1, op);
+}
+template <class tensor>
+EvolutionOperator<tensor> make_twosite_EvolutionOperator(int source_site,
+                                                         int source_leg,
+                                                         tensor const &op) {
+  if (source_site < 0) {
+    throw std::runtime_error("source_site must be non-negative");
+  }
+  if (source_leg < 0 || source_leg > 3) {
+    throw std::runtime_error("source_leg must be 0, 1, 2, or 3");
+  }
+  return EvolutionOperator<tensor>(source_site, source_leg, op);
+}
 
 template <class tensor>
-using NNOperators = std::vector<NNOperator<tensor>>;
+using EvolutionOperators = std::vector<EvolutionOperator<tensor>>;
 
 }  // namespace tenes
 

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -47,10 +47,12 @@ TEST_CASE("input") {
 
     CHECK(peps_parameters.CHI == 2);
 
-    CHECK(peps_parameters.num_simple_step == 0);
+    CHECK(peps_parameters.num_simple_step.size() == 1);
+    CHECK(peps_parameters.num_simple_step[0] == 0);
     CHECK(peps_parameters.Inverse_lambda_cut == 1e-12);
 
-    CHECK(peps_parameters.num_full_step == 0);
+    CHECK(peps_parameters.num_full_step.size() == 1);
+    CHECK(peps_parameters.num_full_step[0] == 0);
     CHECK(peps_parameters.Inverse_Env_cut == 1e-12);
     CHECK(peps_parameters.Full_Inverse_precision == 1e-12);
     CHECK(peps_parameters.Full_Convergence_Epsilon == 1e-6);
@@ -105,10 +107,12 @@ seed = 42)");
 
     CHECK(peps_parameters.CHI == 16);
 
-    CHECK(peps_parameters.num_simple_step == 1000);
+    CHECK(peps_parameters.num_simple_step.size() == 1);
+    CHECK(peps_parameters.num_simple_step[0] == 1000);
     CHECK(peps_parameters.Inverse_lambda_cut == 1e-10);
 
-    CHECK(peps_parameters.num_full_step == 1);
+    CHECK(peps_parameters.num_full_step.size() == 1);
+    CHECK(peps_parameters.num_full_step[0] == 1);
     CHECK(peps_parameters.Inverse_Env_cut == 1e-10);
     CHECK(peps_parameters.Full_Inverse_precision == 1e-10);
     CHECK(peps_parameters.Full_Convergence_Epsilon == 1e-10);
@@ -167,6 +171,7 @@ elements = """
       const auto simple_updates = tenes::itps::load_simple_updates<ptensor>(toml, MPI_COMM_WORLD);
       CHECK(simple_updates[0].source_site == 0);
       CHECK(simple_updates[0].source_leg == 2);
+      CHECK(simple_updates[0].group == 0);
       auto &op = simple_updates[0].op;
       CHECK(op.shape() == mptensor::Shape{2, 2, 2, 4});
       std::complex<double> v = 0.0;
@@ -189,6 +194,7 @@ elements = """
       const auto full_updates = tenes::itps::load_full_updates<ptensor>(toml, MPI_COMM_WORLD);
       CHECK(full_updates[0].source_site == 0);
       CHECK(full_updates[0].source_leg == 2);
+      CHECK(full_updates[0].group == 0);
       auto &op = full_updates[0].op;
       CHECK(op.shape() == mptensor::Shape{2, 2, 2, 4});
       std::complex<double> v = 0.0;

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -498,13 +498,17 @@ class LatticeGraph:
 class SiteOperator:
     site: int
     elements: np.ndarray
+    group: Optional[int]
 
-    def __init__(self, site: int, elements: np.ndarray):
+    def __init__(self, site: int, elements: np.ndarray, group: Optional[int] = None):
         self.site = site
         self.elements = elements
+        self.group = group
 
     def to_toml_strs(self, unitcell) -> List[str]:
         ret = []
+        if self.group is not None:
+            ret.append("group = {}".format(self.group))
         ret.append("site = {}".format(self.site))
         ret.append("dimensions = {}".format(list(self.elements.shape)))
         it = np.nditer(
@@ -531,11 +535,18 @@ class NNOperator:
     bond: Bond
     elements: Optional[np.ndarray]
     ops: Optional[List[int]]
+    group = Optional[int]
 
     def __init__(
-        self, bond: Bond, *, elements: np.ndarray = None, ops: List[int] = None
+        self,
+        bond: Bond,
+        *,
+        elements: Optional[np.ndarray] = None,
+        ops: Optional[List[int]] = None,
+        group: Optional[int] = None
     ):
         self.bond = bond
+        self.group = group
         if elements is not None:
             self.elements = elements
             self.ops = None
@@ -545,6 +556,8 @@ class NNOperator:
 
     def to_toml_strs(self, unitcell: Unitcell) -> List[str]:
         ret = []
+        if self.group is not None:
+            ret.append("group = {}".format(self.group))
         ret.append("source_site = {}".format(self.bond.source_site))
         ret.append("source_leg = {}".format(unitcell.bond_direction(self.bond)))
         if self.elements is not None:
@@ -690,17 +703,19 @@ def make_evolution_onesite(
     hamiltonian: SiteOperator,
     graph: LatticeGraph,
     tau: float,
+    group: int = 0,
     result_cutoff: float = 1e-15,
 ) -> List[SiteOperator]:
     D, V = np.linalg.eigh(hamiltonian.elements)
     evo = np.einsum("il, l, jl -> ij", V, np.exp(-tau * D), V)
-    return [SiteOperator(hamiltonian.site, evo)]
+    return [SiteOperator(hamiltonian.site, evo, group=group)]
 
 
 def make_evolution_twosite(
     hamiltonian: NNOperator,
     graph: LatticeGraph,
     tau: float,
+    group: int = 0,
     result_cutoff: float = 1e-15,
 ) -> List[NNOperator]:
     if hamiltonian.elements is None:
@@ -717,7 +732,7 @@ def make_evolution_twosite(
     bonds = graph.make_path(hamiltonian.bond)
     nhops = len(bonds)
     if nhops == 1:
-        return [NNOperator(hamiltonian.bond, elements=evo)]
+        return [NNOperator(hamiltonian.bond, elements=evo, group=group)]
 
     mdofs = []
     unitcell = graph.unitcell
@@ -758,19 +773,24 @@ def make_evolution(
     hamiltonian: Operator,
     graph: LatticeGraph,
     tau: float,
+    group: int = 0,
     result_cutoff: float = 1e-15,
 ) -> Union[List[SiteOperator], List[NNOperator]]:
     if isinstance(hamiltonian, SiteOperator):
-        return make_evolution_onesite(hamiltonian, graph, tau, result_cutoff)
+        return make_evolution_onesite(
+            hamiltonian, graph, tau, group=group, result_cutoff=result_cutoff
+        )
     else:
-        return make_evolution_twosite(hamiltonian, graph, tau, result_cutoff)
+        return make_evolution_twosite(
+            hamiltonian, graph, tau, group=group, result_cutoff=result_cutoff
+        )
 
 
 class Model:
     param: Dict[str, Dict[str, Any]]
     parameter: Dict[str, Any]
-    simple_tau: float
-    full_tau: float
+    simple_tau: List[float]
+    full_tau: List[float]
     correlation: Dict[str, Any]
     clength: Dict[str, Any]
     unitcell: Unitcell
@@ -785,8 +805,16 @@ class Model:
         param = lower_dict(param)
         self.param = param
         self.parameter = param["parameter"]
-        self.simple_tau = self.parameter["simple_update"].get("tau", 0.01)
-        self.full_tau = self.parameter["full_update"].get("tau", 0.01)
+        tau = self.parameter["simple_update"].get("tau", [0.01])
+        if isinstance(tau, float):
+            self.simple_tau = [tau]
+        else:
+            self.simple_tau = tau
+        tau = self.parameter["full_update"].get("tau", [0.01])
+        if isinstance(tau, float):
+            self.full_tau = [tau]
+        else:
+            self.full_tau = tau
         self.correlation = param.get("correlation", None)
         self.clength = param.get("correlation_length", None)
 
@@ -905,11 +933,14 @@ class Model:
         self.simple_updates = []
         self.full_updates = []
 
-        for ham in self.hamiltonians:
-            for evo in make_evolution(ham, self.graph, self.simple_tau):
-                self.simple_updates.append(evo)
-            for evo in make_evolution(ham, self.graph, self.full_tau):
-                self.full_updates.append(evo)
+        for g, tau in enumerate(self.simple_tau):
+            for ham in self.hamiltonians:
+                for evo in make_evolution(ham, self.graph, tau, group=g):
+                    self.simple_updates.append(evo)
+        for g, tau in enumerate(self.full_tau):
+            for ham in self.hamiltonians:
+                for evo in make_evolution(ham, self.graph, tau, group=g):
+                    self.full_updates.append(evo)
 
     def to_toml(self, f: TextIO):
         # parameter


### PR DESCRIPTION
(This PR is for developers)

In preparation for the implementation of finite temperature calculation and time evolution, I update the format of parameters on the (imaginary) time evolution procedure:

- (`tenes`) `tenes::itps::PEPSParameter::num_(simple|full)_step` becomes `vector<int>` from `int`
    - (`input.toml`) `parameter.(simple|full)_update.num_step` can take a list as a value
- (`tenes`) `tenes::itps::PEPSParameter::tau_(simple|full)_step` is introduced (currently not used)
    - (`input.toml`) `parameter.(simple|full)_update.tau` (float or list of floats) is read in `tenes`
- (`tenes`) rename `tenes::NNOperator` to `tenes::EvolutionOperator`
- (`tenes`) `tenes::EvolutionOperator` has a new parameter, `int group`
	- (`input.toml`) `evolution.(simple|full).group`
    - currently, `group > 0` evolution operators are loaded but ignored in the calculation

The backward compatibility is held; the previous input files are available without modification.