### PR TITLE
Reduce bond dimension of CTM $\chi$ in updating CTM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,3 +7,4 @@
 - Real-time evolution (https://github.com/issp-center-dev/TeNeS/pull/68)
 - Multisite observables (https://github.com/issp-center-dev/TeNeS/pull/69)
 - Finite temperature calculation (https://github.com/issp-center-dev/TeNeS/pull/75)
+- The bond dimension of CTM is automatically reduced in updating CTM (https://github.com/issp-center-dev/TeNeS/pull/77)


### PR DESCRIPTION
While tiny singular values will be zero before this PR, now the CTM tensors themselves shrink.

This has been implemented and works well for the iTPO algorithm (finite temperature mode).