### PR TITLE
Fix missing group parameter in path-decomposed evolution operators

### DIFF
--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -951,9 +951,9 @@ def make_evolution_twosite(
         U = np.dot(U, np.diag(S))
         B = U.reshape((A.shape[0], A.shape[1], dofs[0], -1))
         A = Vt.reshape([B.shape[3]] + dofs[2:] + dofs[1:])
-        ret.append(NNOperator(bond, elements=B))
+        ret.append(NNOperator(bond, elements=B, group=group))
         dofs.pop(0)
-    ret.append(NNOperator(bonds[-1], elements=A))
+    ret.append(NNOperator(bonds[-1], elements=A, group=group))
     return ret
 
 


### PR DESCRIPTION
## Summary

Fixes a bug where the `group` parameter was not being passed to evolution operators generated through path decomposition in the `make_evolution_twosite` function.

## Problem

When two-site Hamiltonian operators require path decomposition (when source and target sites are not directly connected), the generated `NNOperator` instances were missing the `group` parameter. This caused the `group` field to be absent in TOML output.

**This issue particularly manifests when using triangular lattices or other non-square lattices, combined with multiple imaginary time evolution groups.**

## Solution

Added `group=group` parameter to `NNOperator` constructor calls in the path decomposition loop.

## Impact

- Ensures consistent `group` parameter handling across all evolution operators
- Fixes TOML output to include proper `group` fields for path-decomposed operators