### PR TITLE
Fix out-of-bounds access in Check_Convergence_CTM

### DIFF
--- a/src/iTPS/core/ctm.cpp
+++ b/src/iTPS/core/ctm.cpp
@@ -22,7 +22,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <limits>
 #include <numeric>
 #include <vector>
 #include <mptensor/complex.hpp>
@@ -815,19 +814,22 @@ void Bottom_move(const std::vector<tensor> &C1, const std::vector<tensor> &C2,
 
 namespace {
 //! Distance between two sets of normalized singular values.
-/*! Returns infinity (treated as "not converged") when the two vectors have
- *  different lengths. This happens when the number of singular values of a
- *  corner tensor changes between CTM iterations; comparing them element-wise
- *  would otherwise read out of bounds.
+/*! Singular values are in descending order and each vector is L2-normalized.
+ *  When the counts differ (the CTM bond dimension is still growing, or the
+ *  projector cutoff truncates a different number of values between iterations),
+ *  the shorter vector is padded with zeros. The missing entries are the
+ *  smallest singular values, so treating them as zero is consistent with the
+ *  truncation itself and avoids the out-of-bounds access of a naive
+ *  element-wise loop.
  */
 inline double singular_value_distance(const std::vector<double> &lam_new,
                                       const std::vector<double> &lam_old) {
-  if (lam_new.size() != lam_old.size()) {
-    return std::numeric_limits<double>::infinity();
-  }
+  const size_t n = std::max(lam_new.size(), lam_old.size());
   double sig = 0.0;
-  for (size_t j = 0; j < lam_new.size(); ++j) {
-    sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
+  for (size_t j = 0; j < n; ++j) {
+    const double a = j < lam_new.size() ? lam_new[j] : 0.0;
+    const double b = j < lam_old.size() ? lam_old[j] : 0.0;
+    sig += (a - b) * (a - b);
   }
   return std::sqrt(sig);
 }

--- a/src/iTPS/core/ctm.cpp
+++ b/src/iTPS/core/ctm.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <vector>
 #include <mptensor/complex.hpp>
@@ -812,6 +813,26 @@ void Bottom_move(const std::vector<tensor> &C1, const std::vector<tensor> &C2,
   }
 }
 
+namespace {
+//! Distance between two sets of normalized singular values.
+/*! Returns infinity (treated as "not converged") when the two vectors have
+ *  different lengths. This happens when the number of singular values of a
+ *  corner tensor changes between CTM iterations; comparing them element-wise
+ *  would otherwise read out of bounds.
+ */
+inline double singular_value_distance(const std::vector<double> &lam_new,
+                                      const std::vector<double> &lam_old) {
+  if (lam_new.size() != lam_old.size()) {
+    return std::numeric_limits<double>::infinity();
+  }
+  double sig = 0.0;
+  for (size_t j = 0; j < lam_new.size(); ++j) {
+    sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
+  }
+  return std::sqrt(sig);
+}
+}  // unnamed namespace
+
 template <class tensor>
 bool Check_Convergence_CTM(
     const std::vector<tensor> &C1, const std::vector<tensor> &C2,
@@ -846,11 +867,7 @@ bool Check_Convergence_CTM(
       lam_old[k] /= norm;
     }
 
-    sig = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
-      sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
-    }
-    sig = sqrt(sig);
+    sig = singular_value_distance(lam_new, lam_old);
 
     if (sig > peps_parameters.CTM_Convergence_Epsilon) {
       sig_max = sig;
@@ -882,11 +899,7 @@ bool Check_Convergence_CTM(
       lam_old[k] /= norm;
     }
 
-    sig = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
-      sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
-    }
-    sig = sqrt(sig);
+    sig = singular_value_distance(lam_new, lam_old);
 
     if (sig > peps_parameters.CTM_Convergence_Epsilon) {
       sig_max = sig;
@@ -917,11 +930,7 @@ bool Check_Convergence_CTM(
       lam_old[k] /= norm;
     }
 
-    sig = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
-      sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
-    }
-    sig = sqrt(sig);
+    sig = singular_value_distance(lam_new, lam_old);
 
     if (sig > peps_parameters.CTM_Convergence_Epsilon) {
       sig_max = sig;
@@ -951,11 +960,7 @@ bool Check_Convergence_CTM(
       lam_old[k] /= norm;
     }
 
-    sig = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
-      sig += (lam_new[j] - lam_old[j]) * (lam_new[j] - lam_old[j]);
-    }
-    sig = sqrt(sig);
+    sig = singular_value_distance(lam_new, lam_old);
 
     if (sig > peps_parameters.CTM_Convergence_Epsilon) {
       sig_max = sig;


### PR DESCRIPTION
## Summary

`Check_Convergence_CTM` (`src/iTPS/core/ctm.cpp`) compares the normalized
singular values of the new and old corner tensors by looping up to
`lam_new.size()`. When the number of singular values differs between CTM
iterations, `lam_old[j]` (or `lam_new[j]`) is read out of bounds.

This is harmless in release builds but aborts under libstdc++ assertions
(e.g. GCC Debug builds), which is where it was discovered: the `Honeycomb`
`ctest` case crashed with
`stl_vector.h: Assertion '__n < this->size()' failed`.

### Why the counts differ

The number of singular values of a corner tensor is not fixed at CHI:

- CHI is only an upper bound; the environment dimension grows toward CHI over
  the first few iterations.
- The projector cutoff (`Inverse_projector_cut`) may truncate a different
  number of singular values between iterations, so the effective dimension can
  be below CHI and can move up or down.

## Fix

Extract the comparison into a helper `singular_value_distance()` that pads the
shorter vector with zeros before computing the L2 distance. The singular
values are in descending order, so the missing entries are the smallest ones;
treating them as zero is consistent with the CTM truncation itself and yields a
smooth convergence measure, rather than over-conservatively flagging every size
change as "not converged". Behavior is unchanged when the counts match. This
also removes the four-fold duplicated loop (C1..C4).

## Testing

- Debug build (GCC): `Honeycomb` now passes; no regression in the rest of the
  suite.
- Release build: behavior unchanged (all affected cases pass before and after).

Note: the remaining Debug-only failures in `FT_TFI_square` / `FT_Kitaev`
originate in mptensor's `make_l2g_map` (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)