### PR TITLE
Fix onsite repulsion U being ignored in the Bose-Hubbard model of tenes_simple

### DIFF
--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -933,7 +933,7 @@ class BoseHubbardModel(Model):
     def model_sitehamiltonian(self, params_onesite: Dict) -> np.ndarray:
         N, Bdagger, B = self.onesite_ops
         mu = params_onesite.get("mu", 0.0)
-        U = params_onesite.get("U", 0.0)
+        U = params_onesite.get("u", 0.0)
         ham = np.zeros([self.N] * 2, dtype=np.complex128)
         for input, output in product(range(self.N), repeat=2):
             ham[input, output] -= mu * N[input, output]


### PR DESCRIPTION
## Summary

`tenes_simple` silently drops the onsite repulsion `U` of the Bose-Hubbard
model when `--use-site-hamiltonian` is specified.

## Details

`BoseHubbardModel.model_sitehamiltonian` looks up the onsite repulsion with
the uppercase key `"U"`:

```python
mu = params_onesite.get("mu", 0.0)
U = params_onesite.get("U", 0.0)   # always returns the default 0.0
```

However, `read_params` stores the parameter under the lowercase key `"u"`
(input keys are lowercased by `lower_dict`), so this lookup always returns
the default `0.0`.

As a result, when `--use-site-hamiltonian` is specified:

- the site Hamiltonian is built without the `U/2 n(n-1)` term, and
- the bond Hamiltonian also sets `U = 0` (as intended, because the onsite
  terms are delegated to the site Hamiltonian),

so the onsite repulsion vanishes from the generated model entirely. No error
or warning is emitted; the generated input just describes a different model
(free bosons with hopping) than the user requested.

Without `--use-site-hamiltonian` the bug does not manifest, because the bond
Hamiltonian path correctly uses `params_onesite.get("u", 0.0)`.

## Fix

Use the lowercase key, consistent with `read_params` and with
`model_bondhamiltonian`:

```python
U = params_onesite.get("u", 0.0)
```

## Verification

Building the site Hamiltonian for `nmax = 2, U = 3` and checking the
diagonal element for `n = 2` (`U/2 * 2 * 1 = 3`) gives `0.0` before this
fix and `3.0` after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)