### PR TITLE
Fix bugs found in a code review of the C++ core and Python tools

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
       - name: pip install
         run: |
           python -m pip install -U pip
-          python -m pip install numpy scipy toml
+          python -m pip install numpy scipy toml pytest
 
       - name: make workspace
         run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
       - name: pip install
         run: |
           python3 -m pip install -U pip
-          python3 -m pip install numpy scipy toml
+          python3 -m pip install numpy scipy toml pytest
 
       - name: make workspace
         run: cmake -E make_directory ${{runner.workspace}}/build

--- a/src/arnoldi.cpp
+++ b/src/arnoldi.cpp
@@ -21,10 +21,12 @@
 #include <complex>     // for complex, ope...
 #include <functional>  // for function
 #include <ostream>
+#include <sstream>
 #include <vector>      // for __vector_bas...
 
 #include "util/abs.hpp"
 #include "tensor.hpp"
+#include "exception.hpp"
 
 using mptensor::Shape;
 using dcomplex = std::complex<double>;
@@ -59,17 +61,26 @@ void Arnoldi<ptensor>::run(std::function<void(ptensor&, ptensor const&)> A,
   if (mpisize < 0){
     throw std::runtime_error("Arnoldi::run: initialize() has not been called");
   }
-  if (mindim < nev) {
-    mindim = nev;
+  if (nev > maxvec) {
+    std::stringstream ss;
+    ss << "Arnoldi::run: the number of eigenvalues " << nev
+       << " exceeds the dimension of the Krylov subspace " << maxvec;
+    throw tenes::input_error(ss.str());
+  }
+  size_t minvec = mindim > 0 ? static_cast<size_t>(mindim) : 0;
+  if (minvec < nev) {
+    minvec = nev;
+  }
+  if (minvec > maxvec) {
+    minvec = maxvec;
   }
   this->nev = nev;
-  int iter = 0;
   for (size_t k = 1; k <= nev; ++k) {
     A(Q[k], Q[k - 1]);
     orthonormalize(k);
   }
   double res_nev = 1.0;
-  for (size_t iter = 1; iter <= maxiter; ++iter) {
+  for (int iter = 1; iter <= maxiter; ++iter) {
     for (size_t k = nev + 1; k <= maxvec; ++k) {
       A(Q[k], Q[k - 1]);
       orthonormalize(k);
@@ -82,7 +93,7 @@ void Arnoldi<ptensor>::run(std::function<void(ptensor&, ptensor const&)> A,
     if (res_nev <= rtol || iter == maxiter) {
       break;
     }
-    restart(mindim);
+    restart(minvec);
   }
 }
 
@@ -117,6 +128,9 @@ dcomplex real_if_real(dcomplex v, dcomplex) { return v; }
 template <class ptensor>
 void Arnoldi<ptensor>::restart(size_t minvec, double cutoff) {
   size_t k = maxvec;
+  if (minvec >= k) {
+    return;
+  }
   auto h = slice(H, 0, 0, maxvec);
   std::vector<dcomplex> eigvals, vecs_last;
   eigen(h, eigvals, vecs_last, maxvec);

--- a/src/iTPS/PEPS_Parameters.cpp
+++ b/src/iTPS/PEPS_Parameters.cpp
@@ -285,8 +285,10 @@ void PEPS_Parameters::save(const char *filename, bool append) {
       break;
     case PEPS_Parameters::CalculationMode::time_evolution:
       ofs << "time evolution" << std::endl;
+      break;
     case PEPS_Parameters::CalculationMode::finite_temperature:
       ofs << "finite temperature" << std::endl;
+      break;
     default:
       break;
   }

--- a/src/iTPS/PEPS_Parameters.cpp
+++ b/src/iTPS/PEPS_Parameters.cpp
@@ -227,13 +227,13 @@ void PEPS_Parameters::save(const char *filename, bool append) {
 
   // Simple update
   ofs << "simple_num_step = [";
-  for (int i = 0; i < num_simple_step.size(); ++i) {
+  for (std::size_t i = 0; i < num_simple_step.size(); ++i) {
     if (i != 0) ofs << ", ";
     ofs << num_simple_step[i];
   }
   ofs << "]" << std::endl;
   ofs << "simple_tau = [";
-  for (int i = 0; i < tau_simple_step.size(); ++i) {
+  for (std::size_t i = 0; i < tau_simple_step.size(); ++i) {
     if (i != 0) ofs << ", ";
     ofs << tau_simple_step[i];
   }
@@ -248,7 +248,7 @@ void PEPS_Parameters::save(const char *filename, bool append) {
 
   // Full update
   ofs << "full_num_step = [";
-  for (int i = 0; i < num_full_step.size(); ++i) {
+  for (std::size_t i = 0; i < num_full_step.size(); ++i) {
     if (i != 0) ofs << ", ";
     ofs << num_full_step[i];
   }

--- a/src/iTPS/core/contract_itps_mf/correlation.cpp
+++ b/src/iTPS/core/contract_itps_mf/correlation.cpp
@@ -74,7 +74,7 @@ typename tensor::value_type FinishCorrelation_iTPS_MF(const tensor &A,
   direction %= 4;
 
   Axes axes;
-  for(int d=0; d<4; ++d){
+  for(size_t d=0; d<4; ++d){
     if (d == direction) continue;
     axes.push(d);
   }

--- a/src/iTPS/core/ctm.cpp
+++ b/src/iTPS/core/ctm.cpp
@@ -304,7 +304,7 @@ void Calc_projector_left_block(const tensor &C1, const tensor &C4,
     const auto comm = C1.get_comm();
     tensor identity_matrix(comm, Shape(e78, e78));
     Index index;
-    for (int i = 0; i < identity_matrix.local_size(); i++) {
+    for (size_t i = 0; i < identity_matrix.local_size(); i++) {
       index = identity_matrix.global_index(i);
       if (index[0] == index[1]) {
         identity_matrix.set_value(index, 1.0);
@@ -477,7 +477,7 @@ void Calc_projector_updown_blocks(
     const MPI_Comm comm = C1.get_comm();
     tensor identity_matrix(comm, Shape(e78, e78));
     Index index;
-    for (int i = 0; i < identity_matrix.local_size(); i++) {
+    for (size_t i = 0; i < identity_matrix.local_size(); i++) {
       index = identity_matrix.global_index(i);
       if (index[0] == index[1]) {
         identity_matrix.set_value(index, 1.0);
@@ -852,20 +852,20 @@ bool Check_Convergence_CTM(
     // C1
     svd(C1[i], lam_new);
     norm = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
+    for (size_t j = 0; j < lam_new.size(); ++j) {
       norm += lam_new[j] * lam_new[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_new.size(); ++k) {
+    for (size_t k = 0; k < lam_new.size(); ++k) {
       lam_new[k] /= norm;
     }
     svd(C1_old[i], lam_old);
     norm = 0.0;
-    for (int j = 0; j < lam_old.size(); ++j) {
+    for (size_t j = 0; j < lam_old.size(); ++j) {
       norm += lam_old[j] * lam_old[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_old.size(); ++k) {
+    for (size_t k = 0; k < lam_old.size(); ++k) {
       lam_old[k] /= norm;
     }
 
@@ -882,22 +882,22 @@ bool Check_Convergence_CTM(
     // C2
     svd(C2[i], lam_new);
     norm = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
+    for (size_t j = 0; j < lam_new.size(); ++j) {
       norm += lam_new[j] * lam_new[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_new.size(); ++k) {
+    for (size_t k = 0; k < lam_new.size(); ++k) {
       lam_new[k] /= norm;
     }
 
     svd(C2_old[i], lam_old);
     norm = 0.0;
-    for (int j = 0; j < lam_old.size(); ++j) {
+    for (size_t j = 0; j < lam_old.size(); ++j) {
       norm += lam_old[j] * lam_old[j];
     }
 
     norm = sqrt(norm);
-    for (int k = 0; k < lam_old.size(); ++k) {
+    for (size_t k = 0; k < lam_old.size(); ++k) {
       lam_old[k] /= norm;
     }
 
@@ -914,21 +914,21 @@ bool Check_Convergence_CTM(
     // C3
     svd(C3[i], lam_new);
     norm = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
+    for (size_t j = 0; j < lam_new.size(); ++j) {
       norm += lam_new[j] * lam_new[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_new.size(); ++k) {
+    for (size_t k = 0; k < lam_new.size(); ++k) {
       lam_new[k] /= norm;
     }
     svd(C3_old[i], lam_old);
     norm = 0.0;
-    for (int j = 0; j < lam_old.size(); ++j) {
+    for (size_t j = 0; j < lam_old.size(); ++j) {
       norm += lam_old[j] * lam_old[j];
     }
 
     norm = sqrt(norm);
-    for (int k = 0; k < lam_old.size(); ++k) {
+    for (size_t k = 0; k < lam_old.size(); ++k) {
       lam_old[k] /= norm;
     }
 
@@ -945,20 +945,20 @@ bool Check_Convergence_CTM(
     // C4
     svd(C4[i], lam_new);
     norm = 0.0;
-    for (int j = 0; j < lam_new.size(); ++j) {
+    for (size_t j = 0; j < lam_new.size(); ++j) {
       norm += lam_new[j] * lam_new[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_new.size(); ++k) {
+    for (size_t k = 0; k < lam_new.size(); ++k) {
       lam_new[k] /= norm;
     }
     svd(C4_old[i], lam_old);
     norm = 0.0;
-    for (int j = 0; j < lam_old.size(); ++j) {
+    for (size_t j = 0; j < lam_old.size(); ++j) {
       norm += lam_old[j] * lam_old[j];
     }
     norm = sqrt(norm);
-    for (int k = 0; k < lam_old.size(); ++k) {
+    for (size_t k = 0; k < lam_old.size(); ++k) {
       lam_old[k] /= norm;
     }
 

--- a/src/iTPS/core/ctm_single.cpp
+++ b/src/iTPS/core/ctm_single.cpp
@@ -43,7 +43,7 @@ using mptensor::Shape;
 template <class tensor>
 std::vector<tensor> Make_single_tensor_density(const std::vector<tensor> &Tn){
   std::vector<tensor> Tn_single;
-  for (int num = 0; num < Tn.size(); ++num) {
+  for (size_t num = 0; num < Tn.size(); ++num) {
     Tn_single.push_back(mptensor::contract(Tn[num], Axes(4), Axes(5)));
   }
   return Tn_single;
@@ -185,7 +185,7 @@ void Calc_projector_left_block_single(const tensor &C1, const tensor &C4,
       std::vector<double> s_c;
       s_c.resize(cut);
 
-      for (int i = 0; i < s_c.size(); ++i) {
+      for (int i = 0; i < static_cast<int>(s_c.size()); ++i) {
         if (s[i] / denom > peps_parameters.Inverse_projector_cut) {
           s_c[i] = 1.0 / sqrt(s[i]);
         } else {
@@ -251,7 +251,7 @@ void Calc_projector_left_block_single(const tensor &C1, const tensor &C4,
     const auto comm = C1.get_comm();
     tensor identity_matrix(comm, Shape(e78, e78));
     Index index;
-    for (int i = 0; i < identity_matrix.local_size(); i++) {
+    for (size_t i = 0; i < identity_matrix.local_size(); i++) {
       index = identity_matrix.global_index(i);
       if (index[0] == index[1]) {
         identity_matrix.set_value(index, 1.0);
@@ -356,7 +356,7 @@ void Calc_projector_updown_blocks_single(
       std::vector<double> s_c;
       s_c.resize(cut);
 
-      for (int i = 0; i < s.size(); ++i) {
+      for (int i = 0; i < static_cast<int>(s.size()); ++i) {
         if (s[i] / denom > peps_parameters.Inverse_projector_cut) {
           s_c[i] = 1.0 / sqrt(s[i]);
         } else {
@@ -422,7 +422,7 @@ void Calc_projector_updown_blocks_single(
     const MPI_Comm comm = C1.get_comm();
     tensor identity_matrix(comm, Shape(e78, e78));
     Index index;
-    for (int i = 0; i < identity_matrix.local_size(); i++) {
+    for (size_t i = 0; i < identity_matrix.local_size(); i++) {
       index = identity_matrix.global_index(i);
       if (index[0] == index[1]) {
         identity_matrix.set_value(index, 1.0);

--- a/src/iTPS/core/local_gauge.cpp
+++ b/src/iTPS/core/local_gauge.cpp
@@ -108,7 +108,7 @@ void fix_local_gauge(const tensor &Tn1, const tensor &Tn2,
   W2.multiply_vector(D2inv, 1);
 
   std::vector<double> lambda1_inv(dc);
-  for (size_t i = 0; i < dc; ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(dc); ++i) {
     if (lambda1[connect1][i] > peps_parameters.Inverse_lambda_cut) {
       lambda1_inv[i] = 1.0 / lambda1[connect1][i];
     } else {
@@ -132,7 +132,7 @@ void fix_local_gauge(const tensor &Tn1, const tensor &Tn2,
   Tn1_new.multiply_vector(lambda_c, connect1);
 
   std::vector<double> lambda2_inv(dc);
-  for (size_t i = 0; i < dc; ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(dc); ++i) {
     if (lambda1[connect2][i] > peps_parameters.Inverse_lambda_cut) {
       lambda2_inv[i] = 1.0 / lambda2[connect2][i];
     } else {

--- a/src/iTPS/core/simple_update.cpp
+++ b/src/iTPS/core/simple_update.cpp
@@ -62,7 +62,7 @@ void Simple_update_bond(const tensor &Tn1, const tensor &Tn2,
 
   for (int i = 0; i < 4; i++) {
     lambda1_inv[i] = std::vector<double>(lambda1[i].size());
-    for (int j = 0; j < lambda1_inv[i].size(); ++j) {
+    for (size_t j = 0; j < lambda1_inv[i].size(); ++j) {
       if (lambda1[i][j] > peps_parameters.Inverse_lambda_cut) {
         lambda1_inv[i][j] = 1.0 / lambda1[i][j];
       } else {
@@ -72,7 +72,7 @@ void Simple_update_bond(const tensor &Tn1, const tensor &Tn2,
   }
   for (int i = 0; i < 4; i++) {
     lambda2_inv[i] = std::vector<double>(lambda2[i].size());
-    for (int j = 0; j < lambda2_inv[i].size(); ++j) {
+    for (size_t j = 0; j < lambda2_inv[i].size(); ++j) {
       if (lambda2[i][j] > peps_parameters.Inverse_lambda_cut) {
         lambda2_inv[i][j] = 1.0 / lambda2[i][j];
       } else {

--- a/src/iTPS/correlation_length.cpp
+++ b/src/iTPS/correlation_length.cpp
@@ -14,12 +14,28 @@
 /* You should have received a copy of the GNU General Public License /
 / along with this program. If not, see http://www.gnu.org/licenses/. */
 
+#include <cmath>
 #include <functional>
+#include <limits>
 #include <memory>
+#include "correlation_length.hpp"
 #include "iTPS.hpp"
 
 namespace tenes {
 namespace itps {
+
+double calc_correlation_length(double e0_abs, double e1_abs, int L) {
+  if (!(e0_abs > 0.0)) {
+    // all eigenvalues vanish; the correlation length is undefined
+    return 0.0;
+  }
+  const double ratio = e1_abs / e0_abs;
+  if (ratio >= 1.0) {
+    // degenerate leading eigenvalues; the correlation length diverges
+    return std::numeric_limits<double>::infinity();
+  }
+  return -L / std::log(ratio);
+}
 
 template <class ptensor>
 std::vector<typename iTPS<ptensor>::transfer_matrix_eigenvalues_type>
@@ -109,8 +125,16 @@ void iTPS<ptensor>::save_correlation_length(
     const int L = dir == 0 ? lattice.LX_noskew : lattice.LY_noskew;
 
     const double e0 = std::abs(eigvals[0]);
-    const double e1 = std::abs(eigvals[1]) / e0;
-    const double correlation_length = -L / std::log(e1);
+    const double correlation_length =
+        calc_correlation_length(e0, std::abs(eigvals[1]), L);
+    if (!std::isfinite(correlation_length) &&
+        peps_parameters.print_level >= PrintLevel::warn) {
+      std::cerr << "WARNING: correlation length for direction " << dir
+                << ", coord " << x
+                << " diverges (the two largest eigenvalues of the transfer "
+                   "matrix are degenerate)"
+                << std::endl;
+    }
 
     if (time) {
       ofs << time.get() << " ";

--- a/src/iTPS/correlation_length.hpp
+++ b/src/iTPS/correlation_length.hpp
@@ -1,0 +1,38 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#ifndef TENES_SRC_ITPS_CORRELATION_LENGTH_HPP_
+#define TENES_SRC_ITPS_CORRELATION_LENGTH_HPP_
+
+namespace tenes {
+namespace itps {
+
+/*! @brief Computes the correlation length from transfer matrix eigenvalues.
+ *
+ *  @param[in] e0_abs absolute value of the largest eigenvalue
+ *  @param[in] e1_abs absolute value of the second largest eigenvalue
+ *  @param[in] L      length of the unit cell along the transfer direction
+ *
+ *  @return xi = -L / log(e1_abs / e0_abs).
+ *          Returns +infinity when the two eigenvalues are degenerate
+ *          (e1_abs >= e0_abs) and 0.0 when e0_abs is not positive.
+ */
+double calc_correlation_length(double e0_abs, double e1_abs, int L);
+
+}  // namespace itps
+}  // namespace tenes
+
+#endif  // TENES_SRC_ITPS_CORRELATION_LENGTH_HPP_

--- a/src/iTPS/finite_temperature.cpp
+++ b/src/iTPS/finite_temperature.cpp
@@ -25,8 +25,8 @@ void iTPS<tensor>::finite_temperature() {
   measure_density(beta, "FT_");
 
   const int num_groups = num_simple_update_groups;
-  if (peps_parameters.measure_interval.size() < num_groups){
-    while(peps_parameters.measure_interval.size() < num_groups){
+  if (peps_parameters.measure_interval.size() < static_cast<std::size_t>(num_groups)){
+    while(peps_parameters.measure_interval.size() < static_cast<std::size_t>(num_groups)){
       peps_parameters.measure_interval.push_back(*peps_parameters.measure_interval.rbegin());
     }
   }

--- a/src/iTPS/iTPS.cpp
+++ b/src/iTPS/iTPS.cpp
@@ -125,13 +125,13 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
       std::cout << "   chi (CTM): " << CHI << std::endl;
       if (peps_parameters.calcmode ==
           PEPS_Parameters::CalculationMode::finite_temperature) {
-        if (CHI < Dmax) {
+        if (CHI < static_cast<std::size_t>(Dmax)) {
           std::cerr << "WARNING: CTM may be too small (chi < D) for "
                        "iTPO (finite_temperature mode)"
                     << std::endl;
         }
       } else {
-        if (CHI < Dmax * Dmax) {
+        if (CHI < static_cast<std::size_t>(Dmax * Dmax)) {
           std::cerr << "WARNING: CTM may be too small (chi < D*D) for iTPS"
                     << std::endl;
         }
@@ -439,7 +439,7 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
   }
 
   site_ops_indices.resize(N_UNIT, std::vector<int>(num_onesite_operators, -1));
-  for (int i = 0; i < onesite_operators.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(onesite_operators.size()); ++i) {
     auto const &op = onesite_operators[i];
     site_ops_indices[op.source_site][op.group] = i;
   }

--- a/src/iTPS/iTPS.cpp
+++ b/src/iTPS/iTPS.cpp
@@ -202,7 +202,8 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
     // }
     simple_update_groups.insert(g);
   }
-  num_simple_update_groups = *simple_update_groups.rbegin() + 1;
+  num_simple_update_groups =
+      simple_update_groups.empty() ? 0 : *simple_update_groups.rbegin() + 1;
   for (int g = 0; g < num_simple_update_groups; ++g) {
     auto it = simple_update_groups.find(g);
     if (it == simple_update_groups.end()) {
@@ -234,7 +235,8 @@ iTPS<tensor>::iTPS(MPI_Comm comm_, PEPS_Parameters peps_parameters_,
     // }
     full_update_groups.insert(g);
   }
-  num_full_update_groups = *full_update_groups.rbegin() + 1;
+  num_full_update_groups =
+      full_update_groups.empty() ? 0 : *full_update_groups.rbegin() + 1;
   for (int g = 0; g < num_full_update_groups; ++g) {
     auto it = full_update_groups.find(g);
     if (it == full_update_groups.end()) {

--- a/src/iTPS/load_toml.cpp
+++ b/src/iTPS/load_toml.cpp
@@ -370,7 +370,7 @@ PEPS_Parameters gen_param(decltype(cpptoml::parse_file("")) param) {
   auto full = param->get_table("full_update");
   if (full != nullptr) {
     load_if(pparam.num_full_step, full, "num_step");
-    load_if(pparam.tau_full_step, simple, "tau");
+    load_if(pparam.tau_full_step, full, "tau");
     load_if(pparam.Full_Inverse_precision, full, "inverse_precision");
     load_if(pparam.Full_Convergence_Epsilon, full, "convergence_epsilon");
     load_if(pparam.Inverse_Env_cut, full, "env_cutoff");

--- a/src/iTPS/load_toml.cpp
+++ b/src/iTPS/load_toml.cpp
@@ -427,7 +427,7 @@ std::tuple<int, std::vector<int>, std::vector<int>> read_multisites(
   }
 
   std::vector<int> dx, dy;
-  for (int i = 1; i < words.size(); i += 2) {
+  for (std::size_t i = 1; i < words.size(); i += 2) {
     dx.push_back(stoi(words[i]));
     dy.push_back(stoi(words[i + 1]));
   }
@@ -493,7 +493,7 @@ Operators<tensor> load_operator(decltype(cpptoml::parse_file("")) param,
     auto dim_arr = param->get_array_of<int64_t>("dim");
     auto dim_int = param->get_as<int>("dim");
     if (dim_arr) {
-      if (dim_arr->size() != nbody) {
+      if (dim_arr->size() != static_cast<std::size_t>(nbody)) {
         std::stringstream ss;
         ss << "operator is " << nbody << "-sites but dim has "
            << dim_arr->size() << " integers";

--- a/src/iTPS/onesite_obs.cpp
+++ b/src/iTPS/onesite_obs.cpp
@@ -161,7 +161,7 @@ void iTPS<ptensor>::save_onesite(
     for (int ilops = 0; ilops < num_onesite_operators; ++ilops) {
       ofs << "# " << ilops << ": " << onesite_operator_names[ilops] << "\n";
     }
-    if (onesite_obs.size() == nlops + 1) {
+    if (onesite_obs.size() == static_cast<std::size_t>(nlops) + 1) {
       ofs << "# -1: norm\n";
     }
     ofs << std::endl;
@@ -184,7 +184,7 @@ void iTPS<ptensor>::save_onesite(
           << std::endl;
     }
   }
-  if (onesite_obs.size() == nlops + 1) {
+  if (onesite_obs.size() == static_cast<std::size_t>(nlops) + 1) {
     // includes norm
     for (int i = 0; i < N_UNIT; ++i) {
       const auto v = onesite_obs[nlops][i];

--- a/src/iTPS/saveload_tensors.cpp
+++ b/src/iTPS/saveload_tensors.cpp
@@ -168,7 +168,7 @@ void iTPS<ptensor>::load_tensors_v1() {
 
     std::getline(ifs, line);
     loaded_CHI = std::stoi(util::drop_comment(line));
-    if (CHI != loaded_CHI) {
+    if (CHI != static_cast<std::size_t>(loaded_CHI)) {
       if (peps_parameters.print_level >= PrintLevel::info) {
         std::cout << "WARNING: parameters.ctm.dimension is " << CHI
                   << " but loaded tensors have CHI = " << loaded_CHI
@@ -343,7 +343,7 @@ void iTPS<ptensor>::load_tensors_v0() {
   for (int i = 0; i < N_UNIT; ++i) {
     const Shape Tshape = Tn[i].shape();
     const int pdim = lattice.physical_dims[i];
-    if (pdim != Tshape[4]) {
+    if (static_cast<std::size_t>(pdim) != Tshape[4]) {
       std::stringstream ss;
       ss << "ERROR: dimension of the physical bond of the tensor " << i
          << " is " << pdim << " but loaded tensor has " << Tshape[4]

--- a/src/iTPS/saveload_tensors.cpp
+++ b/src/iTPS/saveload_tensors.cpp
@@ -120,6 +120,9 @@ void iTPS<ptensor>::load_tensors() {
 template <class ptensor>
 void load_tensor(ptensor &A, std::string const& name, std::string const& directory, int iunit){
   std::string filename = directory + "/" + name + "_" + std::to_string(iunit) + ".dat";
+  if (!util::path_exists(filename)) {
+    throw tenes::load_error("ERROR: cannot find a tensor file: " + filename);
+  }
   ptensor temp;
   temp.load(filename.c_str());
   if (A.rank() != temp.rank()){
@@ -233,11 +236,16 @@ void iTPS<ptensor>::load_tensors_v1() {
   std::vector<double> ls;
   if (mpirank == 0) {
     for (int i = 0; i < N_UNIT; ++i) {
-      std::ifstream ifs(load_dir + "/lambda_" + std::to_string(i) + ".dat");
+      std::string lambda_filename =
+          load_dir + "/lambda_" + std::to_string(i) + ".dat";
+      std::ifstream ifs(lambda_filename.c_str());
       for (int j = 0; j < nleg; ++j) {
         for (int k = 0; k < loaded_shape[i][j]; ++k) {
           double temp = 0.0;
-          ifs >> temp;
+          if (!(ifs >> temp)) {
+            throw tenes::load_error(
+                "ERROR: failed to read lambda values from " + lambda_filename);
+          }
           ls.push_back(temp);
         }
       }
@@ -271,25 +279,37 @@ void iTPS<ptensor>::load_tensors_v0() {
   for (int i = 0; i < N_UNIT; ++i) {
     std::string filename = load_dir + "/";
     std::string suffix = "_" + std::to_string(i) + ".dat";
-    Tn[i].load((filename + "T" + suffix).c_str());
-    eTt[i].load((filename + "Et" + suffix).c_str());
-    eTr[i].load((filename + "Er" + suffix).c_str());
-    eTb[i].load((filename + "Eb" + suffix).c_str());
-    eTl[i].load((filename + "El" + suffix).c_str());
-    C1[i].load((filename + "C1" + suffix).c_str());
-    C2[i].load((filename + "C2" + suffix).c_str());
-    C3[i].load((filename + "C3" + suffix).c_str());
-    C4[i].load((filename + "C4" + suffix).c_str());
+    auto load = [&filename, &suffix](ptensor &A, const char *name) {
+      std::string path = filename + name + suffix;
+      if (!util::path_exists(path)) {
+        throw tenes::load_error("ERROR: cannot find a tensor file: " + path);
+      }
+      A.load(path.c_str());
+    };
+    load(Tn[i], "T");
+    load(eTt[i], "Et");
+    load(eTr[i], "Er");
+    load(eTb[i], "Eb");
+    load(eTl[i], "El");
+    load(C1[i], "C1");
+    load(C2[i], "C2");
+    load(C3[i], "C3");
+    load(C4[i], "C4");
   }
   std::vector<double> ls;
   if (mpirank == 0) {
     for (int i = 0; i < N_UNIT; ++i) {
       const auto vdim = lattice.virtual_dims[i];
-      std::ifstream ifs(load_dir + "/lambda_" + std::to_string(i) + ".dat");
+      std::string lambda_filename =
+          load_dir + "/lambda_" + std::to_string(i) + ".dat";
+      std::ifstream ifs(lambda_filename.c_str());
       for (int j = 0; j < nleg; ++j) {
         for (int k = 0; k < vdim[j]; ++k) {
           double temp = 0.0;
-          ifs >> temp;
+          if (!(ifs >> temp)) {
+            throw tenes::load_error(
+                "ERROR: failed to read lambda values from " + lambda_filename);
+          }
           ls.push_back(temp);
         }
       }

--- a/src/iTPS/saveload_tensors.cpp
+++ b/src/iTPS/saveload_tensors.cpp
@@ -150,7 +150,12 @@ void iTPS<ptensor>::load_tensors_v1() {
 
     std::getline(ifs, line);
     const int format_version = std::stoi(util::drop_comment(line));
-    assert(format_version == 1);
+    if (format_version != 1) {
+      std::stringstream ss;
+      ss << "ERROR: " << filename << " has format version " << format_version
+         << " but load_tensors_v1 supports only version 1";
+      throw tenes::load_error(ss.str());
+    }
 
     std::getline(ifs, line);
     const int loaded_N_UNIT = std::stoi(util::drop_comment(line));

--- a/src/iTPS/simple_update.cpp
+++ b/src/iTPS/simple_update.cpp
@@ -306,10 +306,10 @@ void iTPS<tensor>::simple_update_density_purification(
     tensor identity(
         comm, mptensor::Shape(Tn[source].shape()[5], Tn[target].shape()[5],
                               Tn[source].shape()[5], Tn[target].shape()[5]));
-    for (int j1 = 0; j1 < Tn[source].shape()[5]; ++j1) {
-      for (int k1 = 0; k1 < Tn[target].shape()[5]; ++k1) {
-        for (int j2 = 0; j2 < Tn[source].shape()[5]; ++j2) {
-          for (int k2 = 0; k2 < Tn[target].shape()[5]; ++k2) {
+    for (size_t j1 = 0; j1 < Tn[source].shape()[5]; ++j1) {
+      for (size_t k1 = 0; k1 < Tn[target].shape()[5]; ++k1) {
+        for (size_t j2 = 0; j2 < Tn[source].shape()[5]; ++j2) {
+          for (size_t k2 = 0; k2 < Tn[target].shape()[5]; ++k2) {
             identity.set_value(mptensor::Index(j1, k1, j2, k2),
                                (j1 == j2 && k1 == k2 ? 1.0 : 0.0));
           }

--- a/src/iTPS/tensors.cpp
+++ b/src/iTPS/tensors.cpp
@@ -96,7 +96,7 @@ void iTPS<ptensor>::initialize_tensors() {
       std::vector<double> ran_re(ndim);
       std::vector<double> ran_im(ndim);
 
-      for (int j = 0; j < ndim; j++) {
+      for (size_t j = 0; j < ndim; j++) {
         ran_re[j] = dist(gen);
         ran_im[j] = dist(gen_im);
       }
@@ -112,7 +112,7 @@ void iTPS<ptensor>::initialize_tensors() {
         }
       }
 
-      for (int n = 0; n < Tn[i].local_size(); ++n) {
+      for (size_t n = 0; n < Tn[i].local_size(); ++n) {
         index = Tn[i].global_index(n);
         if (index[0] == 0 && index[1] == 0 && index[2] == 0 && index[3] == 0) {
           auto v = std::complex<double>(dir[index[4]], dir_im[index[4]]);
@@ -192,7 +192,7 @@ void iTPS<ptensor>::initialize_tensors_density() {
       const auto pdim = lattice.physical_dims[i];
       const auto vdim = lattice.virtual_dims[i];
 
-      for (int n = 0; n < Tn[i].local_size(); ++n) {
+      for (size_t n = 0; n < Tn[i].local_size(); ++n) {
         index = Tn[i].global_index(n);
         if (index[0] == 0 && index[1] == 0 && index[2] == 0 && index[3] == 0 &&
             index[4] == index[5]) {

--- a/src/iTPS/time_evolution.cpp
+++ b/src/iTPS/time_evolution.cpp
@@ -28,8 +28,8 @@ void iTPS<tensor>::time_evolution() {
   const bool su = peps_parameters.num_simple_step[0] > 0;
   const int num_groups = su ? num_simple_update_groups : num_full_update_groups;
 
-  if (peps_parameters.measure_interval.size() < num_groups){
-    while(peps_parameters.measure_interval.size() < num_groups){
+  if (peps_parameters.measure_interval.size() < static_cast<std::size_t>(num_groups)){
+    while(peps_parameters.measure_interval.size() < static_cast<std::size_t>(num_groups)){
       peps_parameters.measure_interval.push_back(*peps_parameters.measure_interval.rbegin());
     }
   }

--- a/src/iTPS/transfer_matrix.cpp
+++ b/src/iTPS/transfer_matrix.cpp
@@ -98,7 +98,7 @@ std::vector<std::complex<double>> TransferMatrix<ptensor>::eigenvalues(
   // for debug output
   // const auto mpirank = this->Tn[0].get_comm_rank();
 
-  if (N <= params.maxdim_dense_eigensolver) {
+  if (N <= static_cast<size_t>(params.maxdim_dense_eigensolver)) {
     ptensor matrix = dir == 0 ? matrix_horizontal(fixed_coord)
                               : matrix_vertical(fixed_coord);
 
@@ -115,7 +115,7 @@ std::vector<std::complex<double>> TransferMatrix<ptensor>::eigenvalues(
   } else {  // use Arnoldi
     auto maxvec = params.arnoldi_maxdim;
     auto maxiter = params.arnoldi_maxiter;
-    if (N < maxvec) {
+    if (N < static_cast<size_t>(maxvec)) {
       maxvec = N;
       maxiter = 1;
     }

--- a/src/iTPS/twosite_obs.cpp
+++ b/src/iTPS/twosite_obs.cpp
@@ -327,7 +327,7 @@ void iTPS<ptensor>::save_twosite(
     for (int ilops = 0; ilops < num_twosite_operators; ++ilops) {
       ofs << "# " << ilops << ": " << twosite_operator_names[ilops] << "\n";
     }
-    if (twosite_obs.size() == nlops + 1) {
+    if (twosite_obs.size() == static_cast<std::size_t>(nlops) + 1) {
       ofs << "# -1: norm\n";
     }
     ofs << std::endl;
@@ -349,7 +349,7 @@ void iTPS<ptensor>::save_twosite(
     }
   }
 
-  if (twosite_obs.size() == nlops + 1) {
+  if (twosite_obs.size() == static_cast<std::size_t>(nlops) + 1) {
     // includes norm
     for (const auto &r : twosite_obs[nlops]) {
       auto bond = r.first;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,21 +81,27 @@ int main2(int argc, char **argv) {
   try {
     status =
         tenes::itps::itps_main(input_filename, MPI_COMM_WORLD, print_level);
-  } catch (const tenes::input_error e) {
+  } catch (const tenes::input_error &e) {
     if (mpirank == 0) {
       std::cerr << "[INPUT ERROR]" << std::endl;
       std::cerr << e.what() << std::endl;
     }
     status = 1;
-  } catch (const tenes::load_error e) {
+  } catch (const tenes::load_error &e) {
     if (mpirank == 0) {
       std::cerr << "[TENSOR LOAD ERROR]" << std::endl;
       std::cerr << e.what() << std::endl;
     }
     status = 1;
-  } catch (const tenes::runtime_error e) {
+  } catch (const tenes::runtime_error &e) {
     if (mpirank == 0) {
       std::cerr << "[ERROR]" << std::endl;
+      std::cerr << e.what() << std::endl;
+    }
+    status = 1;
+  } catch (const std::exception &e) {
+    if (mpirank == 0) {
+      std::cerr << "[UNEXPECTED ERROR]" << std::endl;
       std::cerr << e.what() << std::endl;
     }
     status = 1;

--- a/src/mpi.hpp
+++ b/src/mpi.hpp
@@ -113,7 +113,7 @@ int bcast(std::vector<T> &val, int root, MPI_Comm comm) {
   if (rank != root) {
     val.resize(sz);
   }
-  ret = MPI_Bcast(&(val[0]), sz, datatype, root, comm);
+  ret = MPI_Bcast(val.data(), sz, datatype, root, comm);
 #endif
   return ret;
 }
@@ -134,12 +134,12 @@ int bcast(std::vector<std::complex<T>> &val, int root, MPI_Comm comm) {
     val.resize(sz);
   }
   std::vector<T> reim(2 * sz);
-  for (std::size_t i = 0; i < sz; ++i) {
+  for (int i = 0; i < sz; ++i) {
     reim[2 * i] = val[i].real();
     reim[2 * i + 1] = val[i].imag();
   }
-  ret = MPI_Bcast(&(reim[0]), 2 * sz, datatype, root, comm);
-  for (std::size_t i = 0; i < sz; ++i) {
+  ret = MPI_Bcast(reim.data(), 2 * sz, datatype, root, comm);
+  for (int i = 0; i < sz; ++i) {
     val[i] = std::complex<T>(reim[2 * i], reim[2 * i + 1]);
   }
 #endif
@@ -166,7 +166,7 @@ int allreduce_sum(std::vector<T> &val, MPI_Comm comm) {
   const MPI_Datatype datatype = get_MPI_Datatype<T>();
   int N = val.size();
   std::vector<T> recv(val);
-  int ret = MPI_Allreduce(&(val[0]), &(recv[0]), N, datatype, MPI_SUM, comm);
+  int ret = MPI_Allreduce(val.data(), recv.data(), N, datatype, MPI_SUM, comm);
   if (ret != 0) {
     return ret;
   }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -119,7 +119,7 @@ tensor resize_tensor(tensor const& src, mptensor::Shape target_shape) {
     std::stringstream ss;
     ss << "dimension mismatch in resize_tensor: source = " << ndim
        << ", target = " << target_shape.size();
-    tenes::logic_error(ss.str());
+    throw tenes::logic_error(ss.str());
   }
   mptensor::Shape zero = shape;
 

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -58,7 +58,7 @@ template <class T>
 small_tensor<T> identity(std::size_t k, T v) {
   small_tensor<T> ret{mptensor::Shape(k, k)};
   for (std::size_t i = 0; i < k; ++i) {
-    ret.set_value({k, k}, v);
+    ret.set_value({i, i}, v);
   }
   return ret;
 }

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -66,6 +66,9 @@ std::string joinpath(std::vector<std::string> const& xs) {
 
 std::string basename(const std::string& path) {
   auto xs = util::split(path, "/");
+  if (xs.empty()) {
+    return std::string("");
+  }
   return xs[xs.size() - 1];
 }
 

--- a/src/util/read_tensor.hpp
+++ b/src/util/read_tensor.hpp
@@ -68,7 +68,7 @@ ptensor read_tensor(std::string const &str,
         msg << "\n" << line;
         if (linenum2 == linenum) {
           msg << "\n";
-          for (int i = 0; i < line.length(); ++i) {
+          for (std::size_t i = 0; i < line.length(); ++i) {
             msg << "^";
           }
         }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -26,15 +26,14 @@ namespace util {
 std::vector<std::string> split(std::string const &str,
                                std::string const &delim) {
   std::vector<std::string> words;
-  auto index = 0;
-  auto last = str.size();
+  auto index = str.find_first_not_of(delim);
   while (index != std::string::npos) {
     auto next = str.find_first_of(delim, index);
     if (next == std::string::npos) {
-      words.push_back(str.substr(index, last - index + 1));
+      words.push_back(str.substr(index));
       break;
     }
-    words.push_back(str.substr(index, next - index + 1));
+    words.push_back(str.substr(index, next - index));
     index = str.find_first_not_of(delim, next);
   }
   return words;

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -43,7 +43,7 @@ std::string lstrip(std::string const &str, std::string const &delim) {
   std::string ret("");
   auto index = str.find_first_not_of(delim);
   if (index != std::string::npos) {
-    ret = str.substr(index, str.size() - index + 1);
+    ret = str.substr(index);
   }
   return ret;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,8 @@ endif()
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-foreach(basename input simple_update full_update tensor_util util)
+foreach(basename input simple_update full_update tensor_util util
+        correlation_length)
   set(testname "test_${basename}")
   add_executable(${testname} "${basename}.cpp")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-foreach(basename input simple_update full_update tensor_util)
+foreach(basename input simple_update full_update tensor_util util)
   set(testname "test_${basename}")
   add_executable(${testname} "${basename}.cpp")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,19 @@ foreach(basename input simple_update full_update tensor_util util)
   endif()
 endforeach()
 
+# A syntactically broken input file must lead to a clean error exit,
+# not to an abort by an uncaught exception (WILL_FAIL passes on a
+# nonzero exit code but still fails if the process dies on a signal).
+if(ENABLE_MPI)
+  add_test(NAME broken_input
+           COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 1
+                   ${MPIEXEC_POSTFLAGS} $<TARGET_FILE:tenes>
+                   data/broken.toml)
+else()
+  add_test(NAME broken_input COMMAND $<TARGET_FILE:tenes> data/broken.toml)
+endif()
+set_tests_properties(broken_input PROPERTIES WILL_FAIL TRUE)
+
 foreach(name simple_mode std_mode)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${name}.py.in
                  ${CMAKE_CURRENT_BINARY_DIR}/${name}.py @ONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 foreach(basename input simple_update full_update tensor_util util
-        correlation_length saveload)
+        correlation_length saveload arnoldi)
   set(testname "test_${basename}")
   add_executable(${testname} "${basename}.cpp")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 foreach(basename input simple_update full_update tensor_util util
-        correlation_length)
+        correlation_length saveload)
   set(testname "test_${basename}")
   add_executable(${testname} "${basename}.cpp")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-foreach(basename input simple_update full_update)
+foreach(basename input simple_update full_update tensor_util)
   set(testname "test_${basename}")
   add_executable(${testname} "${basename}.cpp")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,10 @@ else()
 endif()
 set_tests_properties(broken_input PROPERTIES WILL_FAIL TRUE)
 
+add_test(NAME python_unittest
+         COMMAND ${TENES_PYTHON_EXECUTABLE} -m pytest
+                 ${CMAKE_CURRENT_SOURCE_DIR}/python)
+
 foreach(name simple_mode std_mode)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${name}.py.in
                  ${CMAKE_CURRENT_BINARY_DIR}/${name}.py @ONLY)

--- a/test/arnoldi.cpp
+++ b/test/arnoldi.cpp
@@ -1,0 +1,78 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+
+#include "../src/arnoldi.hpp"
+#include "../src/tensor.hpp"
+#include "../src/mpi.hpp"
+
+namespace {
+
+using tensor = tenes::real_tensor;
+
+// A x for the diagonal matrix A = diag(2^0, 2^-1, ..., 2^-(N-1)), scaled by 16
+void matvec(tensor &out, tensor const &in, std::size_t N) {
+  out = tensor(mptensor::Shape(N));
+  for (std::size_t i = 0; i < N; ++i) {
+    double v;
+    in.get_value({i}, v);
+    out.set_value({i}, 16.0 * std::pow(2.0, -static_cast<double>(i)) * v);
+  }
+}
+
+tensor ones(std::size_t N) {
+  tensor v{mptensor::Shape(N)};
+  for (std::size_t i = 0; i < N; ++i) {
+    v.set_value({i}, 1.0);
+  }
+  return v;
+}
+
+}  // namespace
+
+TEST_CASE("Arnoldi") {
+  const std::size_t N = 20;
+  const std::size_t maxvec = 10;
+  const std::size_t nev = 2;
+
+  auto A = [](tensor &out, tensor const &in) { matvec(out, in, N); };
+
+  SUBCASE("eigenvalues of a diagonal matrix") {
+    tenes::Arnoldi<tensor> arnoldi(N, maxvec);
+    arnoldi.initialize(ones(N));
+    arnoldi.run(A, nev, 5, 10, 1.0e-8);
+    auto ev = arnoldi.eigenvalues();
+    REQUIRE(ev.size() >= nev);
+    CHECK(std::abs(ev[0]) == doctest::Approx(16.0).epsilon(1.0e-6));
+    CHECK(std::abs(ev[1]) == doctest::Approx(8.0).epsilon(1.0e-6));
+  }
+
+  SUBCASE("mindim larger than maxvec must not hang") {
+    tenes::Arnoldi<tensor> arnoldi(N, maxvec);
+    arnoldi.initialize(ones(N));
+    // an unsatisfiable tolerance forces restarts
+    arnoldi.run(A, nev, 100, 3, 1.0e-300);
+    auto ev = arnoldi.eigenvalues();
+    REQUIRE(ev.size() >= nev);
+    CHECK(std::abs(ev[0]) == doctest::Approx(16.0).epsilon(1.0e-6));
+  }
+}

--- a/test/arnoldi.cpp
+++ b/test/arnoldi.cpp
@@ -14,7 +14,7 @@
 /* You should have received a copy of the GNU General Public License /
 / along with this program. If not, see http://www.gnu.org/licenses/. */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
 
 #include <cmath>
@@ -24,6 +24,14 @@
 #include "../src/arnoldi.hpp"
 #include "../src/tensor.hpp"
 #include "../src/mpi.hpp"
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  doctest::Context context(argc, argv);
+  const int res = context.run();
+  MPI_Finalize();
+  return res;
+}
 
 namespace {
 

--- a/test/correlation_length.cpp
+++ b/test/correlation_length.cpp
@@ -1,0 +1,63 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cmath>
+
+#include "../src/iTPS/correlation_length.hpp"
+
+TEST_CASE("calc_correlation_length") {
+  using tenes::itps::calc_correlation_length;
+
+  SUBCASE("ordinary values") {
+    // e1/e0 = exp(-2)  ->  xi = L / 2
+    CHECK(calc_correlation_length(1.0, std::exp(-2.0), 1) ==
+          doctest::Approx(0.5));
+    CHECK(calc_correlation_length(1.0, std::exp(-2.0), 3) ==
+          doctest::Approx(1.5));
+    // overall scale of the eigenvalues does not matter
+    CHECK(calc_correlation_length(2.0, 2.0 * std::exp(-2.0), 1) ==
+          doctest::Approx(0.5));
+  }
+
+  SUBCASE("degenerate leading eigenvalues give +infinity") {
+    const double xi = calc_correlation_length(1.0, 1.0, 4);
+    CHECK(std::isinf(xi));
+    CHECK(xi > 0.0);
+  }
+
+  SUBCASE("e1 larger than e0 also gives +infinity") {
+    const double xi = calc_correlation_length(1.0, 1.5, 4);
+    CHECK(std::isinf(xi));
+    CHECK(xi > 0.0);
+  }
+
+  SUBCASE("vanishing leading eigenvalue gives 0") {
+    CHECK(calc_correlation_length(0.0, 0.0, 4) == 0.0);
+  }
+
+  SUBCASE("vanishing subleading eigenvalue gives 0") {
+    CHECK(calc_correlation_length(1.0, 0.0, 4) == 0.0);
+  }
+
+  SUBCASE("result is never NaN") {
+    CHECK_FALSE(std::isnan(calc_correlation_length(0.0, 0.0, 4)));
+    CHECK_FALSE(std::isnan(calc_correlation_length(1.0, 1.0, 4)));
+    CHECK_FALSE(std::isnan(calc_correlation_length(1.0, 0.0, 4)));
+  }
+}

--- a/test/data/broken.toml
+++ b/test/data/broken.toml
@@ -1,0 +1,1 @@
+this is [ not valid toml

--- a/test/data/output_TE_TFI/parameters.dat
+++ b/test/data/output_TE_TFI/parameters.dat
@@ -23,7 +23,6 @@ rsvd_oversampling_factor = 2
 meanfield_env = false
 
 mode = time evolution
-finite temperature
 simple
 Lcor = 0
 seed = 11

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -148,6 +148,46 @@ tau = 0.01
     CHECK(peps_parameters.tau_full_step[0] == 0.01);
   }
 
+  SUBCASE("saved mode string") {
+    INFO("saved mode string");
+
+    auto count_occurrences = [](std::string const &filename,
+                                std::string const &key) {
+      std::ifstream ifs(filename);
+      std::string line;
+      int n = 0;
+      while (std::getline(ifs, line)) {
+        if (line.find(key) != std::string::npos) {
+          ++n;
+        }
+      }
+      return n;
+    };
+
+    struct {
+      PEPS_Parameters::CalculationMode mode;
+      const char *name;
+    } cases[] = {
+        {PEPS_Parameters::CalculationMode::ground_state, "ground state"},
+        {PEPS_Parameters::CalculationMode::time_evolution, "time evolution"},
+        {PEPS_Parameters::CalculationMode::finite_temperature,
+         "finite temperature"},
+    };
+
+    for (auto const &c : cases) {
+      PEPS_Parameters peps_parameters;
+      peps_parameters.calcmode = c.mode;
+      const std::string filename = "output_parameters_test.dat";
+      peps_parameters.save(filename.c_str());
+
+      CHECK(count_occurrences(filename, std::string("mode = ") + c.name) == 1);
+      CHECK(count_occurrences(filename, "ground state") +
+                count_occurrences(filename, "time evolution") +
+                count_occurrences(filename, "finite temperature") ==
+            1);
+    }
+  }
+
   SUBCASE("tensor") {
     INFO("tensor");
     auto toml = parse_str(R"(

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -130,6 +130,24 @@ seed = 42)");
     CHECK(peps_parameters.seed == 42);
   }
 
+  SUBCASE("tau is read from its own section") {
+    INFO("tau");
+    auto toml = parse_str(R"(
+[parameter]
+[parameter.simple_update]
+tau = 0.1
+[parameter.full_update]
+tau = 0.01
+)");
+
+    PEPS_Parameters peps_parameters = gen_param(toml->get_table("parameter"));
+
+    REQUIRE(peps_parameters.tau_simple_step.size() == 1);
+    CHECK(peps_parameters.tau_simple_step[0] == 0.1);
+    REQUIRE(peps_parameters.tau_full_step.size() == 1);
+    CHECK(peps_parameters.tau_full_step[0] == 0.01);
+  }
+
   SUBCASE("tensor") {
     INFO("tensor");
     auto toml = parse_str(R"(

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -26,6 +26,7 @@
 #include "../src/mpi.hpp"
 #include "../src/util/string.hpp"
 #include "../src/iTPS/load_toml.hpp"
+#include "../src/iTPS/iTPS.hpp"
 
 auto parse_str(std::string const &str) -> decltype(cpptoml::parse_file("")) {
   std::stringstream ss;
@@ -325,6 +326,31 @@ elements = """
         CHECK(std::imag(v) == 1.0);
       }
     }
+  }
+
+  SUBCASE("iTPS without evolution operators") {
+    INFO("iTPS without evolution operators");
+    // measurement-only setup: no [[evolution.simple]] / [[evolution.full]]
+    auto toml = parse_str(R"(
+[tensor]
+L_sub = [2, 2]
+[[tensor.unitcell]]
+index = []
+physical_dim = 2
+virtual_dim = 2
+initial_state = [1.0, 0.0]
+noise = 0.01
+    )");
+    PEPS_Parameters peps_parameters;
+    peps_parameters.print_level = PrintLevel::none;
+    peps_parameters.outdir = "output_itps_without_evolution";
+    SquareLattice lattice = gen_lattice(toml->get_table("tensor"));
+
+    CHECK_NOTHROW(iTPS<ptensor>(
+        MPI_COMM_WORLD, peps_parameters, lattice,
+        EvolutionOperators<ptensor>{}, EvolutionOperators<ptensor>{},
+        Operators<ptensor>{}, Operators<ptensor>{}, Operators<ptensor>{},
+        CorrelationParameter{}, TransferMatrix_Parameters{}));
   }
 
   SUBCASE("correlation") {}

--- a/test/python/test_tenes_simple.py
+++ b/test/python/test_tenes_simple.py
@@ -26,6 +26,26 @@ sys.path.insert(
 import tenes_simple
 
 
+class TestSpinModelFieldKeys:
+    def test_conflicting_h_and_hz_raise(self):
+        with pytest.raises(RuntimeError):
+            tenes_simple.SpinModel({"type": "spin", "h": 1.0, "hz": 2.0})
+
+    def test_conflicting_g_and_hx_raise(self):
+        with pytest.raises(RuntimeError):
+            tenes_simple.SpinModel({"type": "spin", "g": 1.0, "hx": 2.0})
+
+    def test_deprecated_h_maps_to_hz(self):
+        with pytest.warns(FutureWarning):
+            model = tenes_simple.SpinModel({"type": "spin", "h": 1.5})
+        assert model.params_onesite["hz"] == pytest.approx(1.5)
+
+    def test_deprecated_g_maps_to_hx(self):
+        with pytest.warns(FutureWarning):
+            model = tenes_simple.SpinModel({"type": "spin", "g": 0.5})
+        assert model.params_onesite["hx"] == pytest.approx(0.5)
+
+
 class TestBoseHubbardModel:
     def test_site_hamiltonian_has_onsite_repulsion(self):
         model = tenes_simple.BoseHubbardModel({"type": "boson", "nmax": 2, "u": 3.0})

--- a/test/python/test_tenes_simple.py
+++ b/test/python/test_tenes_simple.py
@@ -1,0 +1,42 @@
+# TeNeS - Massively parallel tensor network solver
+# Copyright (C) 2019- The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "tool")
+)
+
+import tenes_simple
+
+
+class TestBoseHubbardModel:
+    def test_site_hamiltonian_has_onsite_repulsion(self):
+        model = tenes_simple.BoseHubbardModel({"type": "boson", "nmax": 2, "u": 3.0})
+        ham = model.sitehamiltonian()
+        # H = -mu n + U/2 n(n-1); for n = 2: U/2 * 2 * 1 = U
+        assert ham[2, 2].real == pytest.approx(3.0)
+        assert ham[2, 2].imag == pytest.approx(0.0)
+        assert ham[1, 1].real == pytest.approx(0.0)
+
+    def test_site_hamiltonian_has_chemical_potential(self):
+        model = tenes_simple.BoseHubbardModel({"type": "boson", "nmax": 2, "mu": 2.0})
+        ham = model.sitehamiltonian()
+        assert ham[1, 1].real == pytest.approx(-2.0)
+        assert ham[2, 2].real == pytest.approx(-4.0)

--- a/test/python/test_tenes_simple.py
+++ b/test/python/test_tenes_simple.py
@@ -26,6 +26,11 @@ sys.path.insert(
 import tenes_simple
 
 
+def test_model_is_abstract():
+    with pytest.raises(TypeError):
+        tenes_simple.Model()
+
+
 class TestSpinModelFieldKeys:
     def test_conflicting_h_and_hz_raise(self):
         with pytest.raises(RuntimeError):

--- a/test/python/test_tenes_simple.py
+++ b/test/python/test_tenes_simple.py
@@ -35,6 +35,10 @@ class TestBoseHubbardModel:
         assert ham[2, 2].imag == pytest.approx(0.0)
         assert ham[1, 1].real == pytest.approx(0.0)
 
+    def test_twosite_ops_names(self):
+        model = tenes_simple.BoseHubbardModel({"type": "boson"})
+        assert model.twosite_ops_name == ["NN", "BdaggerB", "BBdagger"]
+
     def test_site_hamiltonian_has_chemical_potential(self):
         model = tenes_simple.BoseHubbardModel({"type": "boson", "nmax": 2, "mu": 2.0})
         ham = model.sitehamiltonian()

--- a/test/python/test_tenes_std.py
+++ b/test/python/test_tenes_std.py
@@ -1,0 +1,50 @@
+# TeNeS - Massively parallel tensor network solver
+# Copyright (C) 2019- The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "tool")
+)
+
+import tenes_std
+
+
+class TestUnitcell:
+    def test_valid_unitcell(self):
+        unitcell = tenes_std.Unitcell(
+            {
+                "l_sub": [2, 1],
+                "unitcell": [
+                    {"index": [], "physical_dim": 2, "virtual_dim": 2},
+                ],
+            }
+        )
+        assert unitcell.numsites() == 2
+
+    def test_missing_site_raises_runtime_error(self):
+        with pytest.raises(RuntimeError):
+            tenes_std.Unitcell(
+                {
+                    "l_sub": [2, 1],
+                    "unitcell": [
+                        {"index": [0], "physical_dim": 2, "virtual_dim": 2},
+                    ],
+                }
+            )

--- a/test/python/test_tenes_std.py
+++ b/test/python/test_tenes_std.py
@@ -26,6 +26,47 @@ sys.path.insert(
 import tenes_std
 
 
+def minimal_std_input():
+    """A minimal valid standard-mode input without a [parameter] section."""
+    bonds = "\n".join(
+        "{} {} {}".format(source, dx, dy)
+        for source in range(4)
+        for dx, dy in ((1, 0), (0, 1))
+    )
+    return {
+        "tensor": {
+            "l_sub": [2, 2],
+            "unitcell": [{"index": [], "physical_dim": 2, "virtual_dim": 2}],
+        },
+        "hamiltonian": [
+            {
+                "dim": [2, 2],
+                "bonds": bonds,
+                "elements": "0 0 0 0 1.0 0.0\n1 1 1 1 -1.0 0.0",
+            }
+        ],
+    }
+
+
+class TestModel:
+    def test_missing_parameter_section_is_allowed(self):
+        model = tenes_std.Model(minimal_std_input())
+        assert model.simple_tau == [0.01]
+        assert model.full_tau == [0.01]
+
+    def test_missing_tensor_section_raises(self):
+        param = minimal_std_input()
+        del param["tensor"]
+        with pytest.raises(RuntimeError):
+            tenes_std.Model(param)
+
+    def test_missing_hamiltonian_section_raises(self):
+        param = minimal_std_input()
+        del param["hamiltonian"]
+        with pytest.raises(RuntimeError):
+            tenes_std.Model(param)
+
+
 class TestMergeInputDict:
     def test_known_subsections_are_merged(self):
         d1 = {"parameter": {"general": {"is_real": True}}}

--- a/test/python/test_tenes_std.py
+++ b/test/python/test_tenes_std.py
@@ -23,6 +23,8 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "tool")
 )
 
+import numpy as np
+
 import tenes_std
 
 
@@ -46,6 +48,26 @@ def minimal_std_input():
             }
         ],
     }
+
+
+class TestIsHermite:
+    def test_hermitian(self):
+        A = np.array([[1.0, 1.0j], [-1.0j, 2.0]])
+        assert tenes_std.is_hermite(A)
+
+    def test_not_hermitian(self):
+        A = np.array([[0.0, 1.0], [0.0, 0.0]])
+        assert not tenes_std.is_hermite(A)
+
+    def test_tolerates_rounding_error(self):
+        A = np.array([[1.0, 0.5], [0.5 + 1e-16, 2.0]])
+        assert tenes_std.is_hermite(A)
+
+    def test_nonhermitian_hamiltonian_raises(self):
+        param = minimal_std_input()
+        param["hamiltonian"][0]["elements"] = "0 0 1 1 1.0 0.0"
+        with pytest.raises(RuntimeError):
+            tenes_std.Model(param)
 
 
 class TestModel:

--- a/test/python/test_tenes_std.py
+++ b/test/python/test_tenes_std.py
@@ -50,6 +50,18 @@ def minimal_std_input():
     }
 
 
+class TestParseBond:
+    def test_valid_line(self):
+        bond = tenes_std.parse_bond("0 1 -1")
+        assert bond.source_site == 0
+        assert bond.dx == 1
+        assert bond.dy == -1
+
+    def test_comment_line_returns_none(self):
+        assert tenes_std.parse_bond("# comment") is None
+        assert tenes_std.parse_bond("") is None
+
+
 class TestIsHermite:
     def test_hermitian(self):
         A = np.array([[1.0, 1.0j], [-1.0j, 2.0]])

--- a/test/python/test_tenes_std.py
+++ b/test/python/test_tenes_std.py
@@ -26,6 +26,27 @@ sys.path.insert(
 import tenes_std
 
 
+class TestMergeInputDict:
+    def test_known_subsections_are_merged(self):
+        d1 = {"parameter": {"general": {"is_real": True}}}
+        d2 = {"parameter": {"simple_update": {"num_step": 100}}}
+        tenes_std.merge_input_dict(d1, d2)
+        assert d1["parameter"]["general"]["is_real"] is True
+        assert d1["parameter"]["simple_update"]["num_step"] == 100
+
+    def test_unknown_subsections_are_kept(self):
+        d1 = {"parameter": {"general": {"is_real": True}}}
+        d2 = {"parameter": {"tensor": {"save_dir": "ckpt"}}}
+        tenes_std.merge_input_dict(d1, d2)
+        assert d1["parameter"]["tensor"]["save_dir"] == "ckpt"
+
+    def test_conflicting_keys_raise(self):
+        d1 = {"parameter": {"general": {"is_real": True}}}
+        d2 = {"parameter": {"general": {"is_real": False}}}
+        with pytest.raises(RuntimeError):
+            tenes_std.merge_input_dict(d1, d2)
+
+
 class TestUnitcell:
     def test_valid_unitcell(self):
         unitcell = tenes_std.Unitcell(

--- a/test/saveload.cpp
+++ b/test/saveload.cpp
@@ -1,0 +1,102 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "../src/tensor.hpp"
+#include "../src/mpi.hpp"
+#include "../src/exception.hpp"
+#include "../src/iTPS/load_toml.hpp"
+#include "../src/iTPS/iTPS.hpp"
+
+namespace {
+
+auto parse_str(std::string const &str) -> decltype(cpptoml::parse_file("")) {
+  std::stringstream ss;
+  ss << str;
+  cpptoml::parser p{ss};
+  return p.parse();
+}
+
+}  // namespace
+
+TEST_CASE("save and load tensors") {
+  using namespace tenes;
+  using namespace tenes::itps;
+  using ptensor = real_tensor;
+
+  const std::string dir = "saveload_test_tensors";
+
+  auto toml = parse_str(R"(
+[tensor]
+L_sub = [2, 2]
+[[tensor.unitcell]]
+index = []
+physical_dim = 2
+virtual_dim = 2
+initial_state = [1.0, 0.0]
+noise = 0.01
+  )");
+  SquareLattice lattice = gen_lattice(toml->get_table("tensor"));
+
+  PEPS_Parameters save_params;
+  save_params.print_level = PrintLevel::none;
+  save_params.outdir = "output_saveload_test";
+  save_params.tensor_save_dir = dir;
+
+  // the loading iTPS reads the tensors in its constructor
+  PEPS_Parameters load_params = save_params;
+  load_params.tensor_save_dir = "";
+  load_params.tensor_load_dir = dir;
+
+  auto make_itps = [&lattice](PEPS_Parameters const &params) {
+    return iTPS<ptensor>(MPI_COMM_WORLD, params, lattice,
+                         EvolutionOperators<ptensor>{},
+                         EvolutionOperators<ptensor>{}, Operators<ptensor>{},
+                         Operators<ptensor>{}, Operators<ptensor>{},
+                         CorrelationParameter{}, TransferMatrix_Parameters{});
+  };
+
+  make_itps(save_params).save_tensors();
+
+  SUBCASE("saved tensors can be loaded back") {
+    CHECK_NOTHROW(make_itps(load_params));
+  }
+
+  SUBCASE("missing tensor file is an error") {
+    REQUIRE(std::remove((dir + "/C1_0.dat").c_str()) == 0);
+    CHECK_THROWS_AS(make_itps(load_params), tenes::load_error);
+  }
+
+  SUBCASE("missing lambda file is an error") {
+    REQUIRE(std::remove((dir + "/lambda_2.dat").c_str()) == 0);
+    CHECK_THROWS_AS(make_itps(load_params), tenes::load_error);
+  }
+
+  SUBCASE("truncated lambda file is an error") {
+    {
+      std::ofstream ofs(dir + "/lambda_1.dat");
+      ofs << "1.0" << std::endl;
+    }
+    CHECK_THROWS_AS(make_itps(load_params), tenes::load_error);
+  }
+}

--- a/test/saveload.cpp
+++ b/test/saveload.cpp
@@ -14,7 +14,7 @@
 /* You should have received a copy of the GNU General Public License /
 / along with this program. If not, see http://www.gnu.org/licenses/. */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
 
 #include <cstdio>
@@ -27,6 +27,14 @@
 #include "../src/exception.hpp"
 #include "../src/iTPS/load_toml.hpp"
 #include "../src/iTPS/iTPS.hpp"
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  doctest::Context context(argc, argv);
+  const int res = context.run();
+  MPI_Finalize();
+  return res;
+}
 
 namespace {
 

--- a/test/tensor_util.cpp
+++ b/test/tensor_util.cpp
@@ -21,6 +21,22 @@
 #include "../src/exception.hpp"
 #include "../src/mpi.hpp"
 
+TEST_CASE("identity") {
+  using mptensor::Index;
+
+  const std::size_t k = 3;
+  const double coeff = 2.0;
+  auto I = tenes::identity(k, coeff);
+  REQUIRE(I.shape() == mptensor::Shape(k, k));
+  double v;
+  for (std::size_t i = 0; i < k; ++i) {
+    for (std::size_t j = 0; j < k; ++j) {
+      I.get_value(Index(i, j), v);
+      CHECK(v == (i == j ? coeff : 0.0));
+    }
+  }
+}
+
 TEST_CASE("resize_tensor") {
   using tensor = tenes::real_tensor;
   using mptensor::Index;

--- a/test/tensor_util.cpp
+++ b/test/tensor_util.cpp
@@ -1,0 +1,63 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "../src/tensor.hpp"
+#include "../src/exception.hpp"
+#include "../src/mpi.hpp"
+
+TEST_CASE("resize_tensor") {
+  using tensor = tenes::real_tensor;
+  using mptensor::Index;
+  using mptensor::Shape;
+
+  tensor src(Shape(2, 2));
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      src.set_value(Index(i, j), 10.0 * i + j);
+    }
+  }
+
+  SUBCASE("ndim mismatch throws") {
+    CHECK_THROWS_AS(tenes::resize_tensor(src, Shape(2, 2, 2)),
+                    tenes::logic_error);
+  }
+
+  SUBCASE("extend pads with zero") {
+    tensor A = tenes::resize_tensor(src, Shape(3, 3));
+    REQUIRE(A.shape() == Shape(3, 3));
+    double v;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        A.get_value(Index(i, j), v);
+        const double expected = (i < 2 && j < 2) ? 10.0 * i + j : 0.0;
+        CHECK(v == expected);
+      }
+    }
+  }
+
+  SUBCASE("shrink keeps the leading block") {
+    tensor A = tenes::resize_tensor(src, Shape(1, 2));
+    REQUIRE(A.shape() == Shape(1, 2));
+    double v;
+    for (int j = 0; j < 2; ++j) {
+      A.get_value(Index(0, j), v);
+      CHECK(v == static_cast<double>(j));
+    }
+  }
+}

--- a/test/tensor_util.cpp
+++ b/test/tensor_util.cpp
@@ -14,12 +14,20 @@
 /* You should have received a copy of the GNU General Public License /
 / along with this program. If not, see http://www.gnu.org/licenses/. */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
 
 #include "../src/tensor.hpp"
 #include "../src/exception.hpp"
 #include "../src/mpi.hpp"
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  doctest::Context context(argc, argv);
+  const int res = context.run();
+  MPI_Finalize();
+  return res;
+}
 
 TEST_CASE("identity") {
   using mptensor::Index;

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -14,7 +14,7 @@
 /* You should have received a copy of the GNU General Public License /
 / along with this program. If not, see http://www.gnu.org/licenses/. */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
 
 #include <string>
@@ -25,6 +25,14 @@
 #include "../src/util/read_tensor.hpp"
 #include "../src/tensor.hpp"
 #include "../src/mpi.hpp"
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  doctest::Context context(argc, argv);
+  const int res = context.run();
+  MPI_Finalize();
+  return res;
+}
 
 TEST_CASE("split") {
   using tenes::util::split;

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -1,0 +1,106 @@
+/* TeNeS - Massively parallel tensor network solver /
+/ Copyright (C) 2019- The University of Tokyo */
+
+/* This program is free software: you can redistribute it and/or modify /
+/ it under the terms of the GNU General Public License as published by /
+/ the Free Software Foundation, either version 3 of the License, or /
+/ (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, /
+/ but WITHOUT ANY WARRANTY; without even the implied warranty of /
+/ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the /
+/ GNU General Public License for more details. */
+
+/* You should have received a copy of the GNU General Public License /
+/ along with this program. If not, see http://www.gnu.org/licenses/. */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <string>
+#include <vector>
+
+#include "../src/util/string.hpp"
+#include "../src/util/file.hpp"
+#include "../src/util/read_tensor.hpp"
+#include "../src/tensor.hpp"
+#include "../src/mpi.hpp"
+
+TEST_CASE("split") {
+  using tenes::util::split;
+
+  SUBCASE("words do not contain delimiters") {
+    auto words = split("a b c");
+    REQUIRE(words.size() == 3);
+    CHECK(words[0] == "a");
+    CHECK(words[1] == "b");
+    CHECK(words[2] == "c");
+  }
+
+  SUBCASE("consecutive, leading, and trailing delimiters are skipped") {
+    auto words = split("  1\t\t22  333 ");
+    REQUIRE(words.size() == 3);
+    CHECK(words[0] == "1");
+    CHECK(words[1] == "22");
+    CHECK(words[2] == "333");
+  }
+
+  SUBCASE("empty or delimiter-only input yields no words") {
+    CHECK(split("").empty());
+    CHECK(split(" \t ").empty());
+  }
+
+  SUBCASE("single word") {
+    auto words = split("word");
+    REQUIRE(words.size() == 1);
+    CHECK(words[0] == "word");
+  }
+}
+
+TEST_CASE("strip and drop_comment") {
+  using namespace tenes::util;
+
+  CHECK(strip("  x  ") == "x");
+  CHECK(lstrip("  x") == "x");
+  CHECK(rstrip("x  ") == "x");
+  CHECK(drop_comment("1 2 # comment") == "1 2 ");
+  CHECK(drop_comment("no comment") == "no comment");
+  CHECK(drop_comment("# all comment") == "");
+}
+
+TEST_CASE("basename") {
+  using tenes::util::basename;
+
+  CHECK(basename("foo/bar.dat") == "bar.dat");
+  CHECK(basename("bar.dat") == "bar.dat");
+  CHECK(basename("") == "");
+}
+
+TEST_CASE("read_tensor") {
+  using tensor = tenes::real_tensor;
+  using mptensor::Index;
+  using mptensor::Shape;
+
+  SUBCASE("blank and comment lines are skipped") {
+    const std::string str =
+        "0 0 1.0 0.0\n"
+        "\n"
+        "   \n"
+        "# comment only\n"
+        "1 1 2.0 0.0  # trailing comment\n";
+    tensor A = tenes::util::read_tensor<tensor>(str, Shape(2, 2));
+    double v;
+    A.get_value(Index(0, 0), v);
+    CHECK(v == 1.0);
+    A.get_value(Index(1, 1), v);
+    CHECK(v == 2.0);
+    A.get_value(Index(0, 1), v);
+    CHECK(v == 0.0);
+  }
+
+  SUBCASE("wrong number of columns throws") {
+    CHECK_THROWS_AS(
+        tenes::util::read_tensor<tensor>("0 0 1.0\n", mptensor::Shape(2, 2)),
+        tenes::input_error);
+  }
+}

--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -919,7 +919,7 @@ class BoseHubbardModel(Model):
         for i, j in [(0, 0), (1, 2), (2, 1)]:
             self.twosite_ops.append((i, j))
             self.twosite_ops_name.append(
-                "{}{}".format(self.onesite_ops_name[i], self.onesite_ops[j])
+                "{}{}".format(self.onesite_ops_name[i], self.onesite_ops_name[j])
             )
         self.read_params(param)
 

--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -15,6 +15,7 @@
 # along with this program. If not, see http://www.gnu.org/licenses
 
 import re
+import warnings
 
 from collections import namedtuple
 from itertools import chain, product
@@ -844,25 +845,25 @@ class SpinModel(Model):
                 update(types, ["b"], n, key)
 
         if "h" in modelparam:
-            print(
-                'WARNING: "h" for the longitudial field is deprecated, and will be removed in future.'
+            warnings.warn(
+                '"h" for the longitudinal field is deprecated, '
+                'and will be removed in future. Use "hz" instead.',
+                FutureWarning,
             )
-            print('         Use "hz" instead.')
             if "hz" in modelparam:
-                print('ERROR: Both "hz" and "h" are specified. Use "hz".')
-                sys.exit(1)
+                raise RuntimeError('Both "hz" and "h" are specified. Use "hz".')
             ret_onesite["hz"] = modelparam["h"]
         elif "hz" in modelparam:
             ret_onesite["hz"] = modelparam["hz"]
 
         if "g" in modelparam:
-            print(
-                'WARNING: "g" for the transverse field is deprecated, and will be removed in future.'
+            warnings.warn(
+                '"g" for the transverse field is deprecated, '
+                'and will be removed in future. Use "hx" instead.',
+                FutureWarning,
             )
-            print('         Use "hx" instead.')
             if "hx" in modelparam:
-                print('ERROR: Both "hx" and "g" are specified. Use "hx".')
-                sys.exit(1)
+                raise RuntimeError('Both "hx" and "g" are specified. Use "hx".')
             ret_onesite["hx"] = modelparam["g"]
         elif "hx" in modelparam:
             ret_onesite["hx"] = modelparam["hx"]

--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -510,7 +510,7 @@ class KagomeLattice(Lattice):
         return a0 * x + a1 * y
 
 
-class Model(object):
+class Model(abc.ABC):
     N: int
     onesite_ops: List[np.ndarray]
     onesite_ops_name: List[str]

--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -1296,7 +1296,7 @@ def tenes_simple(
         corparam = param["correlation"]
         ret.append("[correlation]")
         ret.append("r_max = {}".format(corparam["r_max"]))
-        if not "operators" in corparam:
+        if "operators" not in corparam:
             corparam["operators"] = []
             for g in groups:
                 corparam["operators"].append([g, g])

--- a/tool/tenes_simple.py
+++ b/tool/tenes_simple.py
@@ -933,7 +933,7 @@ class BoseHubbardModel(Model):
     def model_sitehamiltonian(self, params_onesite: Dict) -> np.ndarray:
         N, Bdagger, B = self.onesite_ops
         mu = params_onesite.get("mu", 0.0)
-        U = params_onesite.get("U", 0.0)
+        U = params_onesite.get("u", 0.0)
         ham = np.zeros([self.N] * 2, dtype=np.complex128)
         for input, output in product(range(self.N), repeat=2):
             ham[input, output] -= mu * N[input, output]

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -91,7 +91,7 @@ def value_to_str(v) -> str:
 def merge_input_dict(d1: dict, d2: dict) -> None:
     section1 = d1.get("parameter", {})
     section2 = d2.get("parameter", {})
-    subsection_names = ("general", "simple_update", "full_update", "ctm", "random")
+    subsection_names = sorted(set(section1.keys()) | set(section2.keys()))
     for name in subsection_names:
         sub1 = section1.get(name, {})
         sub2 = section2.get(name, {})

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -249,7 +249,7 @@ def is_hermite(A: np.ndarray) -> bool:
     idir = int(np.prod(input_dirs))
     odir = int(np.prod(output_dirs))
     Amat = A.reshape((idir, odir))
-    return bool(np.all(Amat.conjugate().transpose() == Amat))
+    return bool(np.allclose(Amat.conjugate().transpose(), Amat))
 
 
 class LocalTensor:
@@ -1036,7 +1036,8 @@ class Model:
                     dims
                 )
                 elements = load_tensor(ham["elements"], dims + dims, atol=atol)
-                assert is_hermite(elements)
+                if not is_hermite(elements):
+                    raise RuntimeError("hamiltonian elements are not hermitian")
                 sites: List[int] = ham["sites"]
                 if len(sites) == 0:
                     sites = list(range(self.unitcell.numsites()))
@@ -1058,7 +1059,8 @@ class Model:
                     dims
                 )
                 elements = load_tensor(ham["elements"], dims + dims, atol=atol)
-                assert is_hermite(elements)
+                if not is_hermite(elements):
+                    raise RuntimeError("hamiltonian elements are not hermitian")
                 bonds: List[Bond] = []
                 for line in ham["bonds"].strip().splitlines():
                     b = parse_bond(line)

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -175,7 +175,7 @@ class Bond:
         return not self.is_site()
 
 
-def parse_bond(line: str) -> Bond:
+def parse_bond(line: str) -> Optional[Bond]:
     line = drop_comment(line)
     if not line:
         return None
@@ -202,7 +202,7 @@ class Multisite:
         return len(self.dx) + 1
 
 
-def parse_multisite(line: str) -> Multisite:
+def parse_multisite(line: str) -> Optional[Multisite]:
     line = drop_comment(line)
     if not line:
         return None
@@ -571,7 +571,7 @@ class LatticeGraph:
         return localsite + self.unitcell.numsites() * unitcell_index
 
     def graph_coords(self, index: int) -> Tuple[int, int, int]:
-        assert 0 <= index <= self.N
+        assert 0 <= index < self.N
 
         index, localsite = divmod(index, self.unitcell.numsites())
         offset_y, offset_x = divmod(index, self.offset_Lx)
@@ -645,7 +645,7 @@ class NNOperator:
     bond: Bond
     elements: Optional[np.ndarray]
     ops: Optional[List[int]]
-    group = Optional[int]
+    group: Optional[int]
 
     def __init__(
         self,
@@ -1126,11 +1126,11 @@ class Model:
             group = twosite["group"]
             if group == 0:
                 has_zero_twosite = True
-            bonds = [
-                parse_bond(line)
-                for line in twosite["bonds"].strip().splitlines()
-                if parse_bond(line) is not None
-            ]
+            bonds = []
+            for line in twosite["bonds"].strip().splitlines():
+                bond = parse_bond(line)
+                if bond is not None:
+                    bonds.append(bond)
             coeff = twosite.get("coeff", 1.0)
             coeff_im = twosite.get("coeff_im", 0.0)
             if "elements" in twosite:
@@ -1162,11 +1162,11 @@ class Model:
         for multisite in observable.get("multisite", []):
             name = multisite["name"]
             group = multisite["group"]
-            ms = [
-                parse_multisite(line)
-                for line in multisite["multisites"].strip().splitlines()
-                if parse_multisite(line) is not None
-            ]
+            ms = []
+            for line in multisite["multisites"].strip().splitlines():
+                m = parse_multisite(line)
+                if m is not None:
+                    ms.append(m)
             coeff = multisite.get("coeff", 1.0)
             coeff_im = multisite.get("coeff_im", 0.0)
             if "ops" not in multisite:

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -455,11 +455,12 @@ class Unitcell:
             )
             raise RuntimeError(msg)
 
+        undefined = [i for i, site in enumerate(self.sites) if site is None]
+        if undefined:
+            msg = "sites {} are not defined".format(undefined)
+            raise RuntimeError(msg)
+
         failed = False
-        for i, site in enumerate(self.sites):
-            if site is None:
-                print("site {} is not defined".format(i))
-                failed = True
         for i, isite in enumerate(self.sites):
             for idir in (1, 2):
                 idim = isite.virtual_dim[idir]

--- a/tool/tenes_std.py
+++ b/tool/tenes_std.py
@@ -994,21 +994,23 @@ class Model:
 
     def __init__(self, param: MutableMapping, atol: float = 1e-15):
         param = lower_dict(param)
+        for name in ("tensor", "hamiltonian"):
+            if name not in param:
+                msg = '"{}" section is missing in the input'.format(name)
+                raise RuntimeError(msg)
         self.param = param
-        self.parameter = param["parameter"]
-        if "general" in self.parameter:
-            mode = self.parameter["general"].get("mode", "ground state").lower()
-        else:
-            mode = "ground state"
+        self.parameter = param.get("parameter", {})
+        mode = self.parameter.get("general", {}).get("mode", "ground state")
         if not isinstance(mode, str):
             raise ValueError("mode must be a string.")
+        mode = mode.lower()
         self.time_evolution = mode.startswith("time")
-        tau = self.parameter["simple_update"].get("tau", [0.01])
+        tau = self.parameter.get("simple_update", {}).get("tau", [0.01])
         if isinstance(tau, float):
             self.simple_tau = [tau]
         else:
             self.simple_tau = tau
-        tau = self.parameter["full_update"].get("tau", [0.01])
+        tau = self.parameter.get("full_update", {}).get("tau", [0.01])
         if isinstance(tau, float):
             self.full_tau = [tau]
         else:


### PR DESCRIPTION
This PR fixes 20+ bugs found in a systematic code review, including: full-update tau read from the wrong input section, a broken identity() disabling the Arnoldi restart shift, a hang on restartdim > maxdim, crashes and silent data corruption when loading saved tensors with missing or truncated files, and several error-handling defects in the Python tools.

Each fix comes with a unit test (new doctest suites under test/ and a pytest suite under test/python, registered in CTest); all 23 tests pass in both MPI and non-MPI builds.

See the individual commit messages for the details of each fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)