### PR TITLE
Fix HPC build: missing explicit instantiation, and icpx fast-math breaking Inf/NaN handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,15 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# icpx defaults to -fp-model=fast, whose finite-math-only assumption breaks
+# Inf/NaN handling (e.g. divergent correlation lengths and std::isinf/isnan).
+# Force the precise model; add_compile_options here also covers mptensor.
+# The path match is a fallback for CMake < 3.20, which does not know the
+# IntelLLVM compiler id.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_CXX_COMPILER MATCHES "icpx")
+    add_compile_options(-fp-model=precise)
+endif()
+
 option(GIT_SUBMODULE "Check submodules during build" ON)
 option(MPTENSOR_ROOT "External directory where mptensor is installed into" OFF)
 option(CPPTOML_ROOT "External directory where cpptoml is download into" OFF)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The following tools are required for building TeNeS.
 
 - C++17 compiler
   - For Intel compilers, use the newer `icpx`; the classic `icpc` cannot compile mptensor.
+    `icpx` enables `-fp-model=fast` by default, which breaks Inf/NaN handling; the TeNeS build
+    automatically adds `-fp-model=precise`.
 - CMake (>=3.6.0)
 - BLAS/LAPACK
 

--- a/docs/sphinx/en/install.rst
+++ b/docs/sphinx/en/install.rst
@@ -17,6 +17,8 @@ The following tools are required for building TeNeS.
 1. C++17 compiler
 
    - For Intel compilers, use the newer ``icpx``; the classic ``icpc`` cannot compile mptensor.
+     Note that ``icpx`` enables ``-fp-model=fast`` by default, which breaks Inf/NaN handling;
+     the TeNeS build automatically adds ``-fp-model=precise`` to avoid this.
 
 2. CMake (>=3.6.0)
 3. BLAS and LAPACK

--- a/docs/sphinx/ja/install.rst
+++ b/docs/sphinx/ja/install.rst
@@ -17,6 +17,8 @@ TeNeSをコンパイルするには以下のライブラリ・環境が必要で
 1. C++17 compiler
 
    - Intel コンパイラの場合、古い ``icpc`` では mptensor をビルドできないため、新しい ``icpx`` を利用してください。
+     なお、 ``icpx`` はデフォルトで ``-fp-model=fast`` が有効になっており Inf/NaN の扱いが壊れるため、
+     TeNeS のビルドでは自動的に ``-fp-model=precise`` を付加します。
 
 2. CMake (>=3.6.0)
 3. BLAS, LAPACK

--- a/src/iTPS/core/ctm_single.cpp
+++ b/src/iTPS/core/ctm_single.cpp
@@ -1057,6 +1057,11 @@ int Calc_CTM_Environment_density(std::vector<tensor> &C1, std::vector<tensor> &C
   
 // template instantiate
 
+template std::vector<real_tensor> Make_single_tensor_density(
+    const std::vector<real_tensor> &Tn);
+template std::vector<complex_tensor> Make_single_tensor_density(
+    const std::vector<complex_tensor> &Tn);
+
 template void Calc_projector_left_block_single(
     const real_tensor &C1, const real_tensor &C4, const real_tensor &eT1,
     const real_tensor &eT6, const real_tensor &eT7, const real_tensor &eT8,


### PR DESCRIPTION
## Summary

Two independent fixes for failures observed on an HPC system (icpx 2022.2.1 + gcc-toolset-13, MPI build) that do not reproduce on a local macOS build:

### 1. Link error: undefined reference to `Make_single_tensor_density` (cd96fb01)

`Make_single_tensor_density` is declared in `ctm.hpp` and called from `iTPS.cpp`, but `ctm_single.cpp` never explicitly instantiated it — unlike every other template function in that file. Linking only succeeded when the compiler happened to keep the implicit instantiation emitted for the in-TU call from `Calc_CTM_Environment_density`. GCC 13 on Linux inlines that call at `-O3` and drops the symbol, causing an undefined reference at link time. Added the missing explicit instantiations for `real_tensor` and `complex_tensor`.

### 2. `test_correlation_length` failure with icpx (131cc970)

icpx defaults to `-fp-model=fast` (finite-math-only), under which `std::isinf`/`std::isnan` are constant-folded to `false`. This broke:

- `test_correlation_length` (a divergent correlation length can no longer be detected as `+inf`)
- more importantly, the NaN-sentinel logic in `onesite_obs.cpp`, which would let unmeasured sites leak `nan` rows into `onesite_obs.dat` / `density.dat`

The build now forces `-fp-model=precise` when icpx is detected (with a compiler-path fallback for CMake < 3.20, which does not know the `IntelLLVM` compiler id); the flag also propagates to the bundled mptensor. GCC/Clang builds are unaffected. Noted the behavior in README and the install guides.

## Test plan

- [x] macOS, g++-16, `_NO_MPI`, Release: build + all 23 ctest entries pass; no stray flag added
- [x] HPC, icpx 2022.2.1, MPI/ScaLAPACK, Release: build succeeds and ctest passes (previously failed to link, then failed `test_correlation_length`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)