### PR TITLE
Make MPI builds work on macOS with Homebrew Open MPI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - Building TeNeS now requires a C++17 compiler and mptensor v0.5.0 or later ([#104][], [#109][])
 - The minimum required CMake version is raised from 3.6 to 3.8, so that the language standard is honored in configure-time checks (CMP0067); note that the bundled toml11 requires CMake 3.16 or later anyway ([#112][])
-- On macOS, CMake now locates a Homebrew libomp instead of assuming `/usr/local`: it queries `brew --prefix libomp` and falls back to Homebrew's usual prefixes, then lets `find_package(OpenMP)` drive Apple clang. Building with Apple clang -- including `-DCMAKE_CXX_COMPILER=mpicxx`, since Homebrew's `mpicxx` wraps it -- therefore requires CMake 3.12 or later, which is when `OpenMP_ROOT` started to steer the library search
+- On macOS, CMake now locates a Homebrew libomp instead of assuming `/usr/local`: it queries `brew --prefix libomp` and falls back to Homebrew's usual prefixes, then lets `find_package(OpenMP)` drive Apple clang. Building with Apple clang -- including `-DCMAKE_CXX_COMPILER=mpicxx`, since Homebrew's `mpicxx` wraps it -- therefore requires CMake 3.12 or later, which is when `OpenMP_ROOT` started to steer the library search ([#113][])
 - `tenes`
   - Replaced the TOML parser cpptoml (archived, TOML v0.5.0) with toml11 v4.4.0 (TOML v1.0.0); input errors now report the file name, the line number, and the offending value ([#108][])
   - Writing `[observable.onesite]` and similar sections as a single table instead of an array of tables (`[[...]]`) is now an input error instead of being silently ignored ([#108][])
@@ -23,7 +23,7 @@
   - Fixed Inf/NaN handling with the Intel icpx compiler: the default `-fp-model=fast` broke the detection of divergent correlation lengths and could leak `nan` rows of unmeasured sites into `onesite_obs.dat` / `density.dat`; `-fp-model=precise` is now enforced for icpx builds ([#107][])
   - Fixed an undefined behavior (null-pointer dereference) when the input file has no `[[evolution.simple]]` / `[[evolution.full]]` sections; they are now treated as an empty list of evolution operators ([#108][])
   - Fixed an out-of-bounds access in mptensor (`make_l2g_map`) that aborted finite-temperature calculations in Debug builds, by updating mptensor to v0.5.0 ([#104][])
-  - Fixed an out-of-bounds access in mptensor (`&v[0]` on an empty `std::vector`) that aborted every MPI run with two or more processes in Debug builds. Empty local blocks are routine with the ScaLAPACK backend, and GCC 15 and later enable `_GLIBCXX_ASSERTIONS` by default when compiling without optimization, turning the previously harmless undefined behavior into an abort
+  - Fixed an out-of-bounds access in mptensor (`&v[0]` on an empty `std::vector`) that aborted every MPI run with two or more processes in Debug builds. Empty local blocks are routine with the ScaLAPACK backend, and GCC 15 and later enable `_GLIBCXX_ASSERTIONS` by default when compiling without optimization, turning the previously harmless undefined behavior into an abort ([#113][])
   - `tenes --version` / `--help` no longer initialize MPI, fixing a hang of MPI-linked binaries where the launcher infrastructure is unavailable, e.g. on cluster login nodes ([#111][])
 
 ### Development
@@ -40,7 +40,7 @@
 ### Documentation and samples
 
 - Updated the requirements in README and the install guides: C++17, mptensor >= v0.5.0, dependency list, and notes for Intel compilers ([#104][], [#107][], [#108][])
-- Install guides: how to set up libomp for Apple clang on macOS, a note that Homebrew's `open-mpi` + `scalapack` works with `-DENABLE_MPI=ON` (that ScaLAPACK links OpenBLAS, not Accelerate), and a recommendation to run with `OMP_NUM_THREADS=1` on macOS, where every OpenMP barrier costs a system call
+- Install guides: how to set up libomp for Apple clang on macOS, a note that Homebrew's `open-mpi` + `scalapack` works with `-DENABLE_MPI=ON` (that ScaLAPACK links OpenBLAS, not Accelerate), and a recommendation to run with `OMP_NUM_THREADS=1` on macOS, where every OpenMP barrier costs a system call ([#113][])
 
 ## Changes between v2.1.3 and v2.1.2
 
@@ -136,3 +136,4 @@
 [#110]: https://github.com/issp-center-dev/TeNeS/pull/110
 [#111]: https://github.com/issp-center-dev/TeNeS/pull/111
 [#112]: https://github.com/issp-center-dev/TeNeS/pull/112
+[#113]: https://github.com/issp-center-dev/TeNeS/pull/113

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 - Building TeNeS now requires a C++17 compiler and mptensor v0.5.0 or later ([#104][], [#109][])
 - The minimum required CMake version is raised from 3.6 to 3.8, so that the language standard is honored in configure-time checks (CMP0067); note that the bundled toml11 requires CMake 3.16 or later anyway ([#112][])
+- On macOS, CMake now locates a Homebrew libomp instead of assuming `/usr/local`: it queries `brew --prefix libomp` and falls back to Homebrew's usual prefixes, then lets `find_package(OpenMP)` drive Apple clang. Building with Apple clang -- including `-DCMAKE_CXX_COMPILER=mpicxx`, since Homebrew's `mpicxx` wraps it -- therefore requires CMake 3.12 or later, which is when `OpenMP_ROOT` started to steer the library search
 - `tenes`
   - Replaced the TOML parser cpptoml (archived, TOML v0.5.0) with toml11 v4.4.0 (TOML v1.0.0); input errors now report the file name, the line number, and the offending value ([#108][])
   - Writing `[observable.onesite]` and similar sections as a single table instead of an array of tables (`[[...]]`) is now an input error instead of being silently ignored ([#108][])
@@ -22,6 +23,7 @@
   - Fixed Inf/NaN handling with the Intel icpx compiler: the default `-fp-model=fast` broke the detection of divergent correlation lengths and could leak `nan` rows of unmeasured sites into `onesite_obs.dat` / `density.dat`; `-fp-model=precise` is now enforced for icpx builds ([#107][])
   - Fixed an undefined behavior (null-pointer dereference) when the input file has no `[[evolution.simple]]` / `[[evolution.full]]` sections; they are now treated as an empty list of evolution operators ([#108][])
   - Fixed an out-of-bounds access in mptensor (`make_l2g_map`) that aborted finite-temperature calculations in Debug builds, by updating mptensor to v0.5.0 ([#104][])
+  - Fixed an out-of-bounds access in mptensor (`&v[0]` on an empty `std::vector`) that aborted every MPI run with two or more processes in Debug builds. Empty local blocks are routine with the ScaLAPACK backend, and GCC 15 and later enable `_GLIBCXX_ASSERTIONS` by default when compiling without optimization, turning the previously harmless undefined behavior into an abort
   - `tenes --version` / `--help` no longer initialize MPI, fixing a hang of MPI-linked binaries where the launcher infrastructure is unavailable, e.g. on cluster login nodes ([#111][])
 
 ### Development
@@ -38,6 +40,7 @@
 ### Documentation and samples
 
 - Updated the requirements in README and the install guides: C++17, mptensor >= v0.5.0, dependency list, and notes for Intel compilers ([#104][], [#107][], [#108][])
+- Install guides: how to set up libomp for Apple clang on macOS, a note that Homebrew's `open-mpi` + `scalapack` works with `-DENABLE_MPI=ON` (that ScaLAPACK links OpenBLAS, not Accelerate), and a recommendation to run with `OMP_NUM_THREADS=1` on macOS, where every OpenMP barrier costs a system call
 
 ## Changes between v2.1.3 and v2.1.2
 

--- a/config/openmp.cmake
+++ b/config/openmp.cmake
@@ -8,35 +8,101 @@ macro(openmp)
     endif()
     set(OPENMP_FOUND ON)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    set(_OMP_FLAG "-Xpreprocessor -fopenmp -lomp")
-    if(NOT TENES_OpenMP_INCLUDE_DIR)
-      set(_OMP_INCLUDE_DIR "/usr/local/include")
-    else()
-      set(_OMP_INCLUDE_DIR ${TENES_OpenMP_INCLUDE_DIR})
+    # Apple clang ships without an OpenMP runtime, so libomp has to be
+    # installed separately (Homebrew: `brew install libomp`).  Homebrew's
+    # mpicxx wraps Apple clang, so MPI builds land here as well.
+    #
+    # Locate the libomp prefix.  Homebrew is /opt/homebrew on Apple silicon and
+    # /usr/local on Intel, so ask `brew` rather than hard-coding either one.
+    set(_OMP_PREFIXES)
+    if(OpenMP_ROOT)
+      list(APPEND _OMP_PREFIXES ${OpenMP_ROOT})
     endif()
-    if(NOT TENES_OpenMP_LIBRARY_DIR)
-      set(_OMP_LIBRARY_DIR "/usr/local/lib")
-    else()
-      set(_OMP_LIBRARY_DIR ${TENES_OpenMP_LIBRARY_DIR})
+    if(TENES_OpenMP_LIBRARY_DIR)
+      get_filename_component(_OMP_HINT ${TENES_OpenMP_LIBRARY_DIR} DIRECTORY)
+      list(APPEND _OMP_PREFIXES ${_OMP_HINT})
     endif()
-    try_compile(_AppleClangOMP
-      ${CMAKE_CURRENT_BINARY_DIR}
-      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config/check_omp.cpp
-      CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${_OMP_FLAG}"
-      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${_OMP_INCLUDE_DIR}"
-      CMAKE_FLAGS "-DLINK_DIRECTORIES=${_OMP_LIBRARY_DIR}"
-      OUTPUT_VARIABLE LOG)
-    if(_AppleClangOMP)
-      set(OMP_FLAG -Xpreprocessor -fopenmp)
-      message(STATUS "Found OpenMP: ${OMP_FLAG}")
-      set(OpenMP_CXX_FLAGS -Xpreprocessor -fopenmp)
-      set(OpenMP_CXX_LIBRARIES -lomp)
-      set(OpenMP_CXX_INCLUDE_DIRS ${_OMP_INCLUDE_DIR})
-      set(OpenMP_CXX_LIBRARY_DIRS ${_OMP_LIBRARY_DIR})
-      set(OPENMP_FOUND ON)
+    find_program(TENES_BREW_EXECUTABLE brew)
+    if(TENES_BREW_EXECUTABLE)
+      execute_process(COMMAND ${TENES_BREW_EXECUTABLE} --prefix libomp
+                      OUTPUT_VARIABLE _OMP_BREW_PREFIX
+                      OUTPUT_STRIP_TRAILING_WHITESPACE
+                      ERROR_QUIET)
+      if(_OMP_BREW_PREFIX)
+        list(APPEND _OMP_PREFIXES ${_OMP_BREW_PREFIX})
+      endif()
+    endif()
+    list(APPEND _OMP_PREFIXES
+         /opt/homebrew/opt/libomp /usr/local/opt/libomp /usr/local)
+
+    set(_OMP_PREFIX "")
+    foreach(_prefix IN LISTS _OMP_PREFIXES)
+      if(EXISTS ${_prefix}/include/omp.h)
+        set(_OMP_PREFIX ${_prefix})
+        break()
+      endif()
+    endforeach()
+
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+      # Both OpenMP_ROOT (policy CMP0074) and the SHELL: option prefix used
+      # below require CMake 3.12, so probe the flags by hand on older CMake.
+      # This only feeds TeNeS itself: mptensor runs its own
+      # find_package(OpenMP REQUIRED), which without OpenMP_ROOT cannot find a
+      # Homebrew libomp and stops the configuration.
+      message(STATUS "CMake ${CMAKE_VERSION} predates OpenMP_ROOT; "
+                     "CMake >= 3.12 is recommended for Apple clang builds")
+      if(TENES_OpenMP_INCLUDE_DIR)
+        set(_OMP_INCLUDE_DIR ${TENES_OpenMP_INCLUDE_DIR})
+      else()
+        set(_OMP_INCLUDE_DIR ${_OMP_PREFIX}/include)
+      endif()
+      if(TENES_OpenMP_LIBRARY_DIR)
+        set(_OMP_LIBRARY_DIR ${TENES_OpenMP_LIBRARY_DIR})
+      else()
+        set(_OMP_LIBRARY_DIR ${_OMP_PREFIX}/lib)
+      endif()
+      # try_compile takes a single CMAKE_FLAGS list; repeating the keyword
+      # would drop all but the last entry.
+      try_compile(_AppleClangOMP
+        ${CMAKE_CURRENT_BINARY_DIR}
+        SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config/check_omp.cpp
+        CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=-Xpreprocessor -fopenmp -lomp"
+                    "-DINCLUDE_DIRECTORIES=${_OMP_INCLUDE_DIR}"
+                    "-DLINK_DIRECTORIES=${_OMP_LIBRARY_DIR}"
+        OUTPUT_VARIABLE LOG)
+      if(_AppleClangOMP)
+        set(OMP_FLAG -Xpreprocessor -fopenmp)
+        set(OpenMP_CXX_FLAGS -Xpreprocessor -fopenmp)
+        set(OpenMP_CXX_LIBRARIES -lomp)
+        set(OpenMP_CXX_INCLUDE_DIRS ${_OMP_INCLUDE_DIR})
+        set(OpenMP_CXX_LIBRARY_DIRS ${_OMP_LIBRARY_DIR})
+        set(OPENMP_FOUND ON)
+        message(STATUS "Found OpenMP: ${OMP_FLAG} (libomp in ${_OMP_LIBRARY_DIR})")
+      else()
+        set(OPENMP_FOUND OFF)
+      endif()
     else()
-      message(STATUS "Could NOT find OpenMP")
-      set(OPENMP_FOUND OFF)
+      # CMake's own FindOpenMP knows how to drive Apple clang once it is told
+      # where libomp lives, and it is the only detection mptensor sees -- it
+      # calls find_package(OpenMP REQUIRED) itself.
+      if(_OMP_PREFIX AND NOT OpenMP_ROOT)
+        set(OpenMP_ROOT ${_OMP_PREFIX} CACHE PATH "Root directory of libomp")
+      endif()
+      find_package(OpenMP)
+      if(OPENMP_FOUND)
+        # Here OpenMP_CXX_FLAGS is one space-separated string ("-Xclang
+        # -fopenmp").  It has to reach the compiler as two arguments, and the
+        # SHELL: prefix both splits it and keeps the pair together when the
+        # same flags also arrive through OpenMP::OpenMP_CXX -- plain lists get
+        # de-duplicated down to a dangling "-Xclang".
+        set(OMP_FLAG "SHELL:${OpenMP_CXX_FLAGS}")
+      endif()
+    endif()
+
+    if(NOT OPENMP_FOUND)
+      message(STATUS "Could NOT find OpenMP "
+                     "(hint: brew install libomp, "
+                     "or -DOpenMP_ROOT=<libomp prefix>)")
     endif()
   else()
     find_package(OpenMP)

--- a/docs/sphinx/en/install.rst
+++ b/docs/sphinx/en/install.rst
@@ -101,8 +101,39 @@ In this case, ``tenes``, ``tenes_std`` and ``tenes_simple`` are installed into t
 .. admonition:: Disable MPI/ScaLAPACK parallelization
 
   If you want to disable MPI/ScaLAPACK parallelization, pass ``-DENABLE_MPI=OFF`` option to ``cmake`` command.
-  On macOS, some functions of ScaLAPACK are incompatible with the system's BLAS and LAPACK,
-  and TeNeS ends in error. It is recommended to disable MPI parallel.
+  On macOS, some functions of ScaLAPACK can be incompatible with the system's BLAS and LAPACK
+  and make TeNeS end in error, so ``ENABLE_MPI`` defaults to ``OFF`` there.
+  With ``open-mpi`` and ``scalapack`` installed from Homebrew, ``-DENABLE_MPI=ON``
+  is known to work, because that ScaLAPACK links against OpenBLAS rather than Accelerate.
+
+.. admonition:: OpenMP on macOS
+
+  Apple clang ships without an OpenMP runtime, so libomp has to be installed separately.
+
+  ::
+
+    $ brew install libomp
+
+  CMake queries ``brew --prefix libomp`` and then falls back to Homebrew's usual
+  locations. If the search fails, point it at libomp explicitly.
+
+  ::
+
+    $ cmake -DOpenMP_ROOT=$(brew --prefix libomp) ../
+
+  Note that Homebrew's ``mpicxx`` wraps Apple clang, so ``-DCMAKE_CXX_COMPILER=mpicxx``
+  takes this path as well. Apple clang builds require CMake 3.12 or later,
+  which is when ``OpenMP_ROOT`` started to steer the library search.
+
+.. admonition:: Number of OpenMP threads
+
+  On macOS an OpenMP barrier costs a system call, so fine-grained threading within
+  a node adds far more overhead than it saves. Set ``OMP_NUM_THREADS=1`` at run time
+  and parallelize with MPI instead.
+
+  ::
+
+    $ OMP_NUM_THREADS=1 mpiexec -np 4 tenes input.toml
 
 .. admonition:: Specify compiler
 

--- a/docs/sphinx/ja/install.rst
+++ b/docs/sphinx/ja/install.rst
@@ -103,10 +103,43 @@ macOS (Homebrew) では
 
 
 .. admonition:: MPI/ScaLAPACK 並列化の無効化
-  
+
   MPI および ScaLAPACK を利用しない場合には、 ``-DENABLE_MPI=OFF`` オプションを ``cmake`` コマンドに追加してください。
-  macOS では ScaLAPACK の一部関数とシステムのBLAS, LAPACK とで相性が悪く、エラー終了するのを確認しています。
-  MPI 並列の無効化を推奨しています。
+  macOS では ScaLAPACK の一部関数とシステムのBLAS, LAPACK とで相性が悪く、エラー終了する場合があります。
+  そのため macOS では ``ENABLE_MPI`` の既定値が ``OFF`` になっています。
+  Homebrew で ``open-mpi`` と ``scalapack`` を導入した環境では
+  ``-DENABLE_MPI=ON`` で動作することを確認しています
+  (Homebrew の ScaLAPACK は Accelerate ではなく OpenBLAS にリンクされているため)。
+
+.. admonition:: macOS で OpenMP を使う
+
+  Apple clang には OpenMP ランタイムが同梱されていないため、別途 libomp が必要です。
+
+  ::
+
+    $ brew install libomp
+
+  CMake は ``brew --prefix libomp`` の結果と Homebrew の既定の場所を順に探します。
+  自動検出に失敗する場合は、libomp の場所を明示してください。
+
+  ::
+
+    $ cmake -DOpenMP_ROOT=$(brew --prefix libomp) ../
+
+  なお Homebrew の ``mpicxx`` は Apple clang のラッパーなので、
+  ``-DCMAKE_CXX_COMPILER=mpicxx`` を指定した場合もこの経路になります。
+  Apple clang を使う場合は CMake 3.12 以降が必要です
+  (``OpenMP_ROOT`` によるライブラリ検索が CMake 3.12 で追加されたため)。
+
+.. admonition:: OpenMP スレッド数の指定
+
+  macOS では OpenMP のバリア同期がシステムコールになるため、
+  1 ノード内の細粒度な並列がかえって大きなオーバーヘッドになります。
+  実行時には ``OMP_NUM_THREADS=1`` を設定し、並列化は MPI 側で行うことを推奨します。
+
+  ::
+
+    $ OMP_NUM_THREADS=1 mpiexec -np 4 tenes input.toml
 
 .. admonition:: コンパイラの指定
 


### PR DESCRIPTION
Building TeNeS on macOS with Homebrew's Open MPI hit three independent
problems. This fixes the two that are TeNeS's (or its submodule's) to fix,
and documents the third.

## 1. Debug + MPI aborted at every `np >= 2`

A `CMAKE_BUILD_TYPE=Debug` build with `ENABLE_MPI=ON` aborted during
`simple_update` as soon as more than one process was used:

```
stl_vector.h:1272: std::vector<_Tp, _Alloc>::const_reference
  std::vector<_Tp, _Alloc>::operator[](size_type) const [...]:
  Assertion '__n < this->size()' failed.

  mptensor::matrix::scalapack::Matrix<complex<double>>::head()
  mptensor::matrix::scalapack::replace_matrix_data<complex<double>>(...)
  mptensor::transpose <- mptensor::qr <- tenes::itps::core::Simple_update_bond
```

mptensor took the base address of a `std::vector` as `&(v[0])`, which is an
out-of-bounds access on an empty vector. With the ScaLAPACK backend an empty
local block is an ordinary state, not an edge case: under the block-cyclic
distribution a process that owns no element of a small matrix has an empty
`V`, and `replace_matrix_data()` sizes its send/receive buffers from the
per-peer counts, so they are empty whenever a process exchanges nothing with
a given peer.

The pointer is never dereferenced, so this was harmless until GCC 15, whose
libstdc++ enables `_GLIBCXX_ASSERTIONS` by default for unoptimized builds
(`! defined(__OPTIMIZE__)`; `NDEBUG` plays no part). Release builds keep the
assertions off at `-O2` and above, which is why only Debug builds broke.
This is not macOS-specific -- a Debug MPI build with GCC 15+ on Linux should
hit it too.

Fixed upstream in smorita/mptensor#9 (`&(v[0])` -> `v.data()`, 193 sites);
this PR just moves the submodule to the merge commit.

## 2. `cmake` could not configure with Apple clang

```
-- Could NOT find OpenMP
CMake Error at FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES)
Call Stack: deps/mptensor/CMakeLists.txt:49 (find_package)
-- Configuring incomplete, errors occurred!
```

`config/openmp.cmake` looked for libomp in `/usr/local`, where Homebrew
installs on Intel Macs. On Apple silicon it lives under `/opt/homebrew`, so
OpenMP was never found, `OPENMP_FOUND` went OFF, and the
`find_package(OpenMP REQUIRED)` that mptensor runs on its own then stopped
the configuration outright. This hit a plain `cmake ..` as well as
`-DCMAKE_CXX_COMPILER=mpicxx`, since Homebrew's `mpicxx` wraps Apple clang --
so there was no way to configure an MPI build on Apple silicon without
knowing about the undocumented `TENES_OpenMP_INCLUDE_DIR` /
`TENES_OpenMP_LIBRARY_DIR`.

Now `openmp.cmake` asks `brew --prefix libomp`, falls back to Homebrew's
usual prefixes, and hands the result to CMake's own `FindOpenMP` through
`OpenMP_ROOT` instead of probing the flags by hand. That is the detection
mptensor sees too, so the two agree, and it yields `-Xclang -fopenmp` plus a
full path to `libomp.dylib` rather than `-Xpreprocessor -fopenmp` with a
`link_directories()` search.

The flags need the `SHELL:` prefix: `OpenMP_CXX_FLAGS` is one
space-separated string that has to reach the compiler as two arguments, and a
plain list gets de-duplicated against the copy arriving through
`OpenMP::OpenMP_CXX`, leaving a dangling `-Xclang` that swallows the next
argument (`error: unknown argument: '-MD'`).

Both `OpenMP_ROOT` (policy CMP0074) and `SHELL:` are CMake 3.12 features
while TeNeS still declares 3.8, so the hand-rolled `try_compile` probe stays
as a fallback for older CMake, with the prefix search fixed and the repeated
`CMAKE_FLAGS` keyword -- which kept only its last occurrence -- merged into
one list.

## 3. OpenMP threads are counterproductive on macOS (documented only)

Not a regression and not fixed here, but it is what makes a run look hung, so
the install guide now says to set `OMP_NUM_THREADS=1`.

mptensor enters a small OpenMP parallel region per tensor operation to build
its index maps (`prep_global_to_local`, `make_l2g_map`). macOS's libgomp has
no futex, so every barrier is a `pthread` mutex/condvar system call, and the
fork/join cost dwarfs the actual work. Measured on a 2x2 square-lattice TFI
(D=2, chi=10, 1000 steps, Release):

| np | `OMP_NUM_THREADS` | wall |
|---:|---:|---:|
| 1 | 1 | 0.89 s |
| 1 | 4 | 20.6 s |
| 2 | 1 | 1.77 s |
| 2 | 4 | 51.0 s |
| 4 | 1 | 2.48 s |
| 4 | unset (= 10) | 70.7 s |

A `sample(1)` profile spends essentially all its time in
`gomp_team_barrier_wait_end` -> `__psynch_cvwait`. `GOMP_SPINCOUNT` and
`OMP_WAIT_POLICY=active` barely help (20.6 s -> 17.7 s), and pinning the BLAS
thread counts does not help either. A non-MPI build degrades the same way
(0.25 s -> 9.45 s at 4 threads), so this is not caused by MPI; enabling MPI
merely makes it visible, because `OMP_NUM_THREADS` is then usually left
unset and each rank starts a full thread team.

## Docs

`install.rst` (ja/en) gains: how to install libomp for Apple clang, the note
that Apple clang builds need CMake 3.12+, the `OMP_NUM_THREADS=1`
recommendation, and a correction to the macOS/MPI paragraph. It claimed that
ScaLAPACK is incompatible with the system BLAS/LAPACK and that TeNeS "ends in
error"; Homebrew's ScaLAPACK links OpenBLAS rather than Accelerate, and
`-DENABLE_MPI=ON` works. `ENABLE_MPI` still defaults to OFF on macOS.

## Verification

On macOS 26.6.1 / arm64 with Homebrew open-mpi 5.0.9, scalapack 2.2.3,
libomp 22.1.8, gcc 16.1.0:

| configuration | result |
|---|---|
| g++-16, `ENABLE_MPI=ON`, Debug | ctest 26/26 |
| mpicxx (Apple clang), `ENABLE_MPI=ON`, Release | ctest 26/26 |
| Apple clang, default (`ENABLE_MPI=OFF`) | configures (previously failed) |

The Debug MPI binary was also run directly at 1, 2, 3 and 4 processes on a
D=4 / chi=16 complex case: all complete, with `bond_hamiltonian = -0.5` and
`Sz = 0.5` at every process count. Before the submodule update, `np >= 2`
aborted 100% of the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaygPVJ9fnvkGX9qdVU6HC
